### PR TITLE
redirector/eBPF add initialize failures to provisioning status

### DIFF
--- a/proxy_agent/src/common/constants.rs
+++ b/proxy_agent/src/common/constants.rs
@@ -28,6 +28,8 @@ pub const AUTHORIZATION_HEADER: &str = "x-ms-azure-host-authorization";
 pub const DATE_HEADER: &str = "x-ms-azure-host-date";
 pub const METADATA_HEADER: &str = "Metadata";
 pub const CONNECTION_HEADER: &str = "connection";
+pub const TIME_TICK_HEADER: &str = "x-ms-azure-timetick";
+pub const NOTIFY_HEADER: &str = "x-ms-azure-notify";
 
 // Default Config Settings
 pub const DEFAULT_MAX_EVENT_FILE_COUNT: usize = 30;

--- a/proxy_agent/src/common/constants.rs
+++ b/proxy_agent/src/common/constants.rs
@@ -28,7 +28,7 @@ pub const AUTHORIZATION_HEADER: &str = "x-ms-azure-host-authorization";
 pub const DATE_HEADER: &str = "x-ms-azure-host-date";
 pub const METADATA_HEADER: &str = "Metadata";
 pub const CONNECTION_HEADER: &str = "connection";
-pub const TIME_TICK_HEADER: &str = "x-ms-azure-timetick";
+pub const TIME_TICK_HEADER: &str = "x-ms-azure-time_tick";
 pub const NOTIFY_HEADER: &str = "x-ms-azure-notify";
 
 // Default Config Settings

--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -271,7 +271,7 @@ impl KeyKeeper {
                                 provision_timeup = false;
                             }
                         } else {
-                            // report key latched ready to try update the provision finished timetick
+                            // report key latched ready to try update the provision finished time_tick
                             provision::key_latched(
                                 self.cancellation_token.clone(),
                                 self.key_keeper_shared_state.clone(),

--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -259,14 +259,26 @@ impl KeyKeeper {
                     // this is to handle quicker response to the secure channel state change during VM provisioning.
                     _ = notify.notified() => {
                         if  current_state == DISABLE_STATE || current_state == UNKNOWN_STATE {
-                            logger::write_warning(format!("poll_secure_channel_status task notified and secure channel state is '{}', start poll status now.", current_state));
+                            logger::write_warning(format!("poll_secure_channel_status task notified and secure channel state is '{}', reset states and start poll status now.", current_state));
                             provision::key_latch_ready_state_reset(self.provision_shared_state.clone()).await;
+                            if let Err(e) =  self.key_keeper_shared_state.update_current_secure_channel_state(UNKNOWN_STATE.to_string()).await{
+                                logger::write_warning(format!("Failed to update secure channel state to 'Unknown': {}", e));
+                            }
 
                             if start.elapsed().as_millis() > PROVISION_TIMEUP_IN_MILLISECONDS {
                                 // already timeup, reset the start timer
                                 start = Instant::now();
+                                provision_timeup = false;
                             }
                         } else {
+                            // report key latched ready to try update the provision finished timetick
+                            provision::key_latched(
+                                self.cancellation_token.clone(),
+                                self.key_keeper_shared_state.clone(),
+                                self.telemetry_shared_state.clone(),
+                                self.provision_shared_state.clone(),
+                                self.agent_status_shared_state.clone(),
+                            ).await;
                             let slept_time_in_millisec = time.elapsed().as_millis();
                             let continue_sleep = sleep.as_millis() - slept_time_in_millisec;
                             if continue_sleep > 0 {

--- a/proxy_agent/src/main.rs
+++ b/proxy_agent/src/main.rs
@@ -19,7 +19,7 @@ pub mod test_mock;
 use common::cli::{Commands, CLI};
 use common::constants;
 use common::helpers;
-use provision::ProvisionQuery;
+use provision::provision_query::ProvisionQuery;
 use proxy_agent_shared::misc_helpers;
 use shared_state::SharedState;
 use std::{process, time::Duration};

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -79,9 +79,8 @@
 //! assert_eq!(0, provision_state.1.len());
 //! ```
 
-use crate::common::{
-    config, constants, error::Error, helpers, hyper_client, logger, result::Result,
-};
+use crate::common::{config, logger};
+use crate::key_keeper::{DISABLE_STATE, UNKNOWN_STATE};
 use crate::proxy_agent_status;
 use crate::shared_state::agent_status_wrapper::{AgentStatusModule, AgentStatusSharedState};
 use crate::shared_state::key_keeper_wrapper::KeyKeeperSharedState;
@@ -90,9 +89,6 @@ use crate::shared_state::telemetry_wrapper::TelemetrySharedState;
 use crate::telemetry::event_reader::EventReader;
 use proxy_agent_shared::misc_helpers;
 use proxy_agent_shared::telemetry::event_logger;
-use serde_derive::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
@@ -134,28 +130,24 @@ bitflags::bitflags! {
     }
 }
 
-/// Provision status
-/// finished - provision finished or timedout
-///            true means provision finished or timedout, false means provision still in progress
-/// errorMessage - provision error message
-#[derive(Serialize, Deserialize)]
-#[allow(non_snake_case)]
-pub struct ProvisionState {
-    pub finished: bool,
-    pub errorMessage: String,
+/// Provision internal state
+/// It is used to represent the provision state within GPA service
+/// finished_timetick - provision finished or timedout time tick, 0 means provision still in progress
+/// error_message - provision error message
+/// key_keeper_secure_channel_state - key keeper secure_channel state
+#[derive(Clone, Debug)]
+pub struct ProvisionStateInternal {
+    pub finished_timetick: i128,
+    pub error_message: String,
+    pub key_keeper_secure_channel_state: String,
 }
 
-impl ProvisionState {
-    pub fn new(finished: bool, error_message: String) -> Self {
-        ProvisionState {
-            finished,
-            errorMessage: error_message,
-        }
+impl ProvisionStateInternal {
+    pub fn is_secure_channel_latched(&self) -> bool {
+        self.key_keeper_secure_channel_state != DISABLE_STATE
+            && self.key_keeper_secure_channel_state != UNKNOWN_STATE
     }
 }
-
-/// Provision URL path, it is used to query the provision status from GPA service http listener
-pub const PROVISION_URL_PATH: &str = "/provision";
 
 /// Update provision state when redirector provision finished
 /// It could  be called by redirector module
@@ -502,93 +494,144 @@ async fn get_provision_failed_state_message(
 /// Get provision state
 /// It returns the current GPA serice provision state (from shared_state) for GPA service
 /// This function is designed and invoked in GPA service
-pub async fn get_provision_state(
+pub async fn get_provision_state_internal(
     provision_shared_state: ProvisionSharedState,
     agent_status_shared_state: AgentStatusSharedState,
-) -> ProvisionState {
-    ProvisionState {
-        finished: provision_shared_state
+    key_keeper_shared_state: KeyKeeperSharedState,
+) -> ProvisionStateInternal {
+    ProvisionStateInternal {
+        finished_timetick: provision_shared_state
             .get_provision_finished()
             .await
-            .unwrap_or(false),
-        errorMessage: get_provision_failed_state_message(
+            .unwrap_or(0),
+        error_message: get_provision_failed_state_message(
             provision_shared_state,
             agent_status_shared_state,
         )
         .await,
+        key_keeper_secure_channel_state: key_keeper_shared_state
+            .get_current_secure_channel_state()
+            .await
+            .unwrap_or(UNKNOWN_STATE.to_string()),
     }
 }
 
-/// Provision query
+/// provision query module designed for GPA command line, serves for --status [--wait seconds] option
 /// It is used to query the provision status from GPA service via http request
-/// This struct is designed for GPA command line, serves for --status [--wait seconds] option
-pub struct ProvisionQuery {
-    port: u16,
-    wait_duration: Option<Duration>,
-}
+pub mod provision_query {
+    use crate::common::{constants, error::Error, helpers, hyper_client, logger, result::Result};
+    use proxy_agent_shared::misc_helpers;
+    use serde_derive::{Deserialize, Serialize};
+    use std::{collections::HashMap, net::Ipv4Addr, time::Duration};
 
-impl ProvisionQuery {
-    pub fn new(port: u16, wait_duration: Option<Duration>) -> ProvisionQuery {
-        ProvisionQuery {
-            port,
-            wait_duration,
+    /// Provision URL path, it is used to query the provision status from GPA service http listener
+    pub const PROVISION_URL_PATH: &str = "/provision";
+
+    /// Provision status
+    /// finished - provision finished or timedout
+    ///            true means provision finished or timedout, false means provision still in progress
+    /// errorMessage - provision error message
+    #[derive(Serialize, Deserialize)]
+    #[allow(non_snake_case)]
+    pub struct ProvisionState {
+        pub finished: bool,
+        pub errorMessage: String,
+    }
+
+    impl ProvisionState {
+        pub fn new(finished: bool, error_message: String) -> ProvisionState {
+            ProvisionState {
+                finished,
+                errorMessage: error_message,
+            }
         }
     }
 
-    /// Get current GPA service provision status and wait until the GPA service provision finished or timeout
-    /// This function is designed for GPA command line, serves for --status [--wait seconds] option
-    pub async fn get_provision_status_wait(&self) -> ProvisionState {
-        loop {
-            let state = match self.get_current_provision_status().await {
-                Ok(state) => state,
-                Err(e) => {
-                    println!(
-                        "Failed to query the current provision state with error: {}.",
-                        e
-                    );
-                    ProvisionState::new(false, String::new())
-                }
-            };
-            if state.finished {
-                return state;
-            }
-
-            if let Some(d) = self.wait_duration {
-                if d.as_millis() >= helpers::get_elapsed_time_in_millisec() {
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                    continue;
-                }
-            }
-
-            // wait timedout return as 'not finished' with empty message
-            return ProvisionState::new(false, String::new());
-        }
+    /// Provision query
+    /// It is used to query the provision status from GPA service via http request
+    /// This struct is designed for GPA command line, serves for --status [--wait seconds] option
+    pub struct ProvisionQuery {
+        port: u16,
+        wait_duration: Option<Duration>,
+        query_timetick: i128,
     }
 
-    // Get current provision status from GPA service via http request
-    // return value
-    //  bool - true provision finished; false provision not finished
-    //  String - provision error message, empty means provision success or provision failed.
-    async fn get_current_provision_status(&self) -> Result<ProvisionState> {
-        let provision_url: String = format!(
-            "http://{}:{}{}",
-            Ipv4Addr::LOCALHOST,
-            self.port,
-            PROVISION_URL_PATH
-        );
+    impl ProvisionQuery {
+        pub fn new(port: u16, wait_duration: Option<Duration>) -> ProvisionQuery {
+            ProvisionQuery {
+                port,
+                wait_duration,
+                query_timetick: misc_helpers::get_date_time_unix_nano(),
+            }
+        }
 
-        let provision_url: hyper::Uri = provision_url
-            .parse::<hyper::Uri>()
-            .map_err(|e| Error::ParseUrl(provision_url, e.to_string()))?;
+        /// Get current GPA service provision status and wait until the GPA service provision finished or timeout
+        /// This function is designed for GPA command line, serves for --status [--wait seconds] option
+        pub async fn get_provision_status_wait(&self) -> ProvisionState {
+            let mut first_loop = true;
+            loop {
+                // query the current provision state from GPA service via http request
+                // ask GPA service listener to notify the its key_keeper in the first loop only
+                let state = match self.get_current_provision_status(first_loop).await {
+                    Ok(state) => state,
+                    Err(e) => {
+                        println!(
+                            "Failed to query the current provision state with error: {}.",
+                            e
+                        );
+                        ProvisionState::new(false, String::new())
+                    }
+                };
+                first_loop = false;
+                if state.finished {
+                    return state;
+                }
 
-        let mut headers = HashMap::new();
-        headers.insert(constants::METADATA_HEADER.to_string(), "true".to_string());
-        hyper_client::get(&provision_url, &headers, None, None, logger::write_warning).await
+                if let Some(d) = self.wait_duration {
+                    if d.as_millis() >= helpers::get_elapsed_time_in_millisec() {
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                        continue;
+                    }
+                }
+
+                // wait timedout return as 'not finished' with empty message
+                return ProvisionState::new(false, String::new());
+            }
+        }
+
+        // Get current provision status from GPA service via http request
+        // return value
+        //  bool - true provision finished; false provision not finished
+        //  String - provision error message, empty means provision success or provision failed.
+        async fn get_current_provision_status(&self, notify: bool) -> Result<ProvisionState> {
+            let provision_url: String = format!(
+                "http://{}:{}{}",
+                Ipv4Addr::LOCALHOST,
+                self.port,
+                PROVISION_URL_PATH
+            );
+
+            let provision_url: hyper::Uri = provision_url
+                .parse::<hyper::Uri>()
+                .map_err(|e| Error::ParseUrl(provision_url, e.to_string()))?;
+
+            let mut headers = HashMap::new();
+            headers.insert(constants::METADATA_HEADER.to_string(), "true".to_string());
+            headers.insert(
+                constants::TIME_TICK_HEADER.to_string(),
+                self.query_timetick.to_string(),
+            );
+            if notify {
+                headers.insert(constants::NOTIFY_HEADER.to_string(), "true".to_string());
+            }
+            hyper_client::get(&provision_url, &headers, None, None, logger::write_warning).await
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::provision::provision_query::ProvisionQuery;
     use crate::provision::ProvisionFlags;
     use crate::proxy::proxy_server;
     use crate::shared_state::SharedState;
@@ -626,7 +669,7 @@ mod tests {
         let sleep_duration = Duration::from_millis(100);
         tokio::time::sleep(sleep_duration).await;
 
-        let provision_query = super::ProvisionQuery::new(port, None);
+        let provision_query = ProvisionQuery::new(port, None);
         let provision_status = provision_query.get_provision_status_wait().await;
         assert!(
             !provision_status.finished,
@@ -686,7 +729,7 @@ mod tests {
             "success status.tag file must be empty"
         );
 
-        let provision_query = super::ProvisionQuery::new(port, Some(Duration::from_millis(5)));
+        let provision_query = ProvisionQuery::new(port, Some(Duration::from_millis(5)));
         let provision_status = provision_query.get_provision_status_wait().await;
         assert!(provision_status.finished, "provision_status.0 must be true");
         assert_eq!(

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -565,6 +565,11 @@ pub mod provision_query {
             }
         }
 
+        #[cfg(test)]
+        pub fn get_query_timetick(&self) -> i128 {
+            self.query_timetick
+        }
+
         /// Get current GPA service provision status and wait until the GPA service provision finished or timeout
         /// This function is designed for GPA command line, serves for --status [--wait seconds] option
         pub async fn get_provision_status_wait(&self) -> ProvisionState {
@@ -717,6 +722,9 @@ mod tests {
         for handle in handles {
             handle.await;
         }
+        _ = key_keeper_shared_state
+            .update_current_secure_channel_state(super::DISABLE_STATE.to_string())
+            .await;
 
         let provisioned_file = temp_test_path.join("provisioned.tag");
         assert!(provisioned_file.exists());
@@ -730,8 +738,23 @@ mod tests {
         );
 
         let provision_query = ProvisionQuery::new(port, Some(Duration::from_millis(5)));
+        let provision_state_internal = super::get_provision_state_internal(
+            provision_shared_state.clone(),
+            agent_status_shared_state.clone(),
+            key_keeper_shared_state.clone(),
+        )
+        .await;
+        assert!(
+            provision_state_internal.finished_timetick > 0,
+            "finished_timetick must great than 0"
+        );
+        assert!(!provision_state_internal.is_secure_channel_latched());
+        assert!(
+            provision_state_internal.finished_timetick < provision_query.get_query_timetick(),
+            "finished_timetick must older than the query timetick"
+        );
         let provision_status = provision_query.get_provision_status_wait().await;
-        assert!(provision_status.finished, "provision_status.0 must be true");
+        assert!(!provision_status.finished, "provision_status.0 must be false as secured channel is disabled and provision finished ");
         assert_eq!(
             0,
             provision_status.errorMessage.len(),
@@ -744,10 +767,55 @@ mod tests {
             .unwrap();
         assert!(event_threads_initialized);
 
+        // update provision finish time ticks
+        super::key_latched(
+            cancellation_token.clone(),
+            key_keeper_shared_state.clone(),
+            telemetry_shared_state.clone(),
+            provision_shared_state.clone(),
+            agent_status_shared_state.clone(),
+        )
+        .await;
+        let provision_state_internal = super::get_provision_state_internal(
+            provision_shared_state.clone(),
+            agent_status_shared_state.clone(),
+            key_keeper_shared_state.clone(),
+        )
+        .await;
+        assert!(
+            provision_state_internal.finished_timetick > 0,
+            "finished_timetick must great than 0"
+        );
+        assert!(!provision_state_internal.is_secure_channel_latched());
+        assert!(
+            provision_state_internal.finished_timetick > provision_query.get_query_timetick(),
+            "finished_timetick must later than the query timetick"
+        );
+        let provision_status = provision_query.get_provision_status_wait().await;
+        assert!(
+            provision_status.finished,
+            "provision_status.finished must be true as provision finished time tichs refreshed"
+        );
+        assert_eq!(
+            0,
+            provision_status.errorMessage.len(),
+            "provision_status.1 must be empty"
+        );
+
         // test reset key latch provision state
         super::key_latch_ready_state_reset(provision_shared_state.clone()).await;
         let provision_state = provision_shared_state.get_state().await.unwrap();
         assert!(!provision_state.contains(ProvisionFlags::KEY_LATCH_READY));
+        let provision_state_internal = super::get_provision_state_internal(
+            provision_shared_state.clone(),
+            agent_status_shared_state.clone(),
+            key_keeper_shared_state.clone(),
+        )
+        .await;
+        assert!(
+            provision_state_internal.finished_timetick == 0,
+            "finished_timetick must be 0 as key latch provision state reset"
+        );
         let provision_status = provision_query.get_provision_status_wait().await;
         assert!(
             !provision_status.finished,

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -132,12 +132,12 @@ bitflags::bitflags! {
 
 /// Provision internal state
 /// It is used to represent the provision state within GPA service
-/// finished_timetick - provision finished or timedout time tick, 0 means provision still in progress
+/// finished_time_tick - provision finished or timedout time tick, 0 means provision still in progress
 /// error_message - provision error message
 /// key_keeper_secure_channel_state - key keeper secure_channel state
 #[derive(Clone, Debug)]
 pub struct ProvisionStateInternal {
-    pub finished_timetick: i128,
+    pub finished_time_tick: i128,
     pub error_message: String,
     pub key_keeper_secure_channel_state: String,
 }
@@ -500,7 +500,7 @@ pub async fn get_provision_state_internal(
     key_keeper_shared_state: KeyKeeperSharedState,
 ) -> ProvisionStateInternal {
     ProvisionStateInternal {
-        finished_timetick: provision_shared_state
+        finished_time_tick: provision_shared_state
             .get_provision_finished()
             .await
             .unwrap_or(0),
@@ -553,7 +553,7 @@ pub mod provision_query {
     pub struct ProvisionQuery {
         port: u16,
         wait_duration: Option<Duration>,
-        query_timetick: i128,
+        query_time_tick: i128,
     }
 
     impl ProvisionQuery {
@@ -561,13 +561,13 @@ pub mod provision_query {
             ProvisionQuery {
                 port,
                 wait_duration,
-                query_timetick: misc_helpers::get_date_time_unix_nano(),
+                query_time_tick: misc_helpers::get_date_time_unix_nano(),
             }
         }
 
         #[cfg(test)]
-        pub fn get_query_timetick(&self) -> i128 {
-            self.query_timetick
+        pub fn get_query_time_tick(&self) -> i128 {
+            self.query_time_tick
         }
 
         /// Get current GPA service provision status and wait until the GPA service provision finished or timeout
@@ -624,7 +624,7 @@ pub mod provision_query {
             headers.insert(constants::METADATA_HEADER.to_string(), "true".to_string());
             headers.insert(
                 constants::TIME_TICK_HEADER.to_string(),
-                self.query_timetick.to_string(),
+                self.query_time_tick.to_string(),
             );
             if notify {
                 headers.insert(constants::NOTIFY_HEADER.to_string(), "true".to_string());
@@ -745,13 +745,13 @@ mod tests {
         )
         .await;
         assert!(
-            provision_state_internal.finished_timetick > 0,
-            "finished_timetick must great than 0"
+            provision_state_internal.finished_time_tick > 0,
+            "finished_time_tick must great than 0"
         );
         assert!(!provision_state_internal.is_secure_channel_latched());
         assert!(
-            provision_state_internal.finished_timetick < provision_query.get_query_timetick(),
-            "finished_timetick must older than the query timetick"
+            provision_state_internal.finished_time_tick < provision_query.get_query_time_tick(),
+            "finished_time_tick must older than the query time_tick"
         );
         let provision_status = provision_query.get_provision_status_wait().await;
         assert!(!provision_status.finished, "provision_status.0 must be false as secured channel is disabled and provision finished ");
@@ -767,7 +767,7 @@ mod tests {
             .unwrap();
         assert!(event_threads_initialized);
 
-        // update provision finish time ticks
+        // update provision finish time_tick
         super::key_latched(
             cancellation_token.clone(),
             key_keeper_shared_state.clone(),
@@ -783,13 +783,13 @@ mod tests {
         )
         .await;
         assert!(
-            provision_state_internal.finished_timetick > 0,
-            "finished_timetick must great than 0"
+            provision_state_internal.finished_time_tick > 0,
+            "finished_time_tick must great than 0"
         );
         assert!(!provision_state_internal.is_secure_channel_latched());
         assert!(
-            provision_state_internal.finished_timetick > provision_query.get_query_timetick(),
-            "finished_timetick must later than the query timetick"
+            provision_state_internal.finished_time_tick > provision_query.get_query_time_tick(),
+            "finished_time_tick must later than the query time_tick"
         );
         let provision_status = provision_query.get_provision_status_wait().await;
         assert!(
@@ -813,8 +813,8 @@ mod tests {
         )
         .await;
         assert!(
-            provision_state_internal.finished_timetick == 0,
-            "finished_timetick must be 0 as key latch provision state reset"
+            provision_state_internal.finished_time_tick == 0,
+            "finished_time_tick must be 0 as key latch provision state reset"
         );
         let provision_status = provision_query.get_provision_status_wait().await;
         assert!(

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -794,7 +794,7 @@ mod tests {
         let provision_status = provision_query.get_provision_status_wait().await;
         assert!(
             provision_status.finished,
-            "provision_status.finished must be true as provision finished time tichs refreshed"
+            "provision_status.finished must be true as provision finished_time_tick refreshed"
         );
         assert_eq!(
             0,

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -421,7 +421,7 @@ impl ProxyServer {
             return Ok(Self::empty_response(StatusCode::NOT_FOUND));
         }
 
-        if http_connection_context.url == provision::PROVISION_URL_PATH {
+        if http_connection_context.url == provision::provision_query::PROVISION_URL_PATH {
             return self
                 .handle_provision_state_check_request(http_connection_context.get_logger(), request)
                 .await;
@@ -615,20 +615,60 @@ impl ProxyServer {
             );
             return Ok(Self::empty_response(StatusCode::BAD_REQUEST));
         }
+        // Get the query timetick
+        let query_timetick = match request.headers().get(constants::TIME_TICK_HEADER) {
+            Some(timetick) => timetick.to_str().unwrap_or("0"),
+            None => {
+                logger.write(
+                    LoggerLevel::Warn,
+                    "No 'x-ms-azure-timetick' header found in the request, use '0'.".to_string(),
+                );
+                "0"
+            }
+        };
+        let query_timetick = match query_timetick.parse::<i128>() {
+            Ok(timetick) => timetick,
+            Err(e) => {
+                logger.write(
+                    LoggerLevel::Warn,
+                    format!("Failed to parse TimeTick header: {}", e),
+                );
+                0
+            }
+        };
 
-        // notify key_keeper to poll the status
-        if let Err(e) = self.key_keeper_shared_state.notify().await {
-            logger.write(
-                LoggerLevel::Warn,
-                format!("Failed to notify key_keeper: {}", e),
-            );
-        }
-
-        let provision_state = provision::get_provision_state(
+        let provision_state = provision::get_provision_state_internal(
             self.provision_shared_state.clone(),
             self.agent_status_shared_state.clone(),
+            self.key_keeper_shared_state.clone(),
         )
         .await;
+
+        // check if the provision is finished with the given query_timetick or
+        // the secure channel is latched before
+        let report_provision_finished = provision_state.finished_timetick >= query_timetick
+            || provision_state.is_secure_channel_latched();
+
+        let find_notify_header = request.headers().get(constants::NOTIFY_HEADER).is_some();
+        if find_notify_header && !report_provision_finished {
+            logger.write(
+                LoggerLevel::Warn,
+                "Provision is not finished yet, notify key_keeper to pull the status.".to_string(),
+            );
+            if let Err(e) = self.key_keeper_shared_state.notify().await {
+                logger.write(
+                    LoggerLevel::Warn,
+                    format!("Failed to notify key_keeper: {}", e),
+                );
+            }
+        }
+
+        let provision_state = provision::provision_query::ProvisionState::new(
+            // report as provision finished state
+            // only if the finished_timetick is greater than or equal to the query_timetick
+            report_provision_finished,
+            provision_state.error_message,
+        );
         match serde_json::to_string(&provision_state) {
             Ok(json) => {
                 logger.write(LoggerLevel::Info, format!("Provision state: {}", json));

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -615,23 +615,23 @@ impl ProxyServer {
             );
             return Ok(Self::empty_response(StatusCode::BAD_REQUEST));
         }
-        // Get the query timetick
-        let query_timetick = match request.headers().get(constants::TIME_TICK_HEADER) {
-            Some(timetick) => timetick.to_str().unwrap_or("0"),
+        // Get the query time_tick
+        let query_time_tick = match request.headers().get(constants::TIME_TICK_HEADER) {
+            Some(time_tick) => time_tick.to_str().unwrap_or("0"),
             None => {
                 logger.write(
                     LoggerLevel::Warn,
-                    "No 'x-ms-azure-timetick' header found in the request, use '0'.".to_string(),
+                    "No 'x-ms-azure-time_tick' header found in the request, use '0'.".to_string(),
                 );
                 "0"
             }
         };
-        let query_timetick = match query_timetick.parse::<i128>() {
-            Ok(timetick) => timetick,
+        let query_time_tick = match query_time_tick.parse::<i128>() {
+            Ok(time_tick) => time_tick,
             Err(e) => {
                 logger.write(
                     LoggerLevel::Warn,
-                    format!("Failed to parse TimeTick header: {}", e),
+                    format!("Failed to parse time_tick header: {}", e),
                 );
                 0
             }
@@ -644,9 +644,10 @@ impl ProxyServer {
         )
         .await;
 
-        // check if the provision is finished with the given query_timetick or
-        // the secure channel is latched before
-        let report_provision_finished = provision_state.finished_timetick >= query_timetick
+        // report as provision finished state
+        // true only if the finished_time_tick is greater than or equal to the query_time_tick
+        //          or the secure channel is latched already
+        let report_provision_finished = provision_state.finished_time_tick >= query_time_tick
             || provision_state.is_secure_channel_latched();
 
         let find_notify_header = request.headers().get(constants::NOTIFY_HEADER).is_some();
@@ -664,8 +665,6 @@ impl ProxyServer {
         }
 
         let provision_state = provision::provision_query::ProvisionState::new(
-            // report as provision finished state
-            // only if the finished_timetick is greater than or equal to the query_timetick
             report_provision_finished,
             provision_state.error_message,
         );

--- a/proxy_agent/src/redirector.rs
+++ b/proxy_agent/src/redirector.rs
@@ -146,9 +146,12 @@ impl Redirector {
         }
 
         for _ in 0..5 {
-            if let Err(e) = self.start_internal().await {
-                self.set_error_status(format!("Failed to start redirector: {e}"))
-                    .await;
+            match self.start_internal().await {
+                Ok(_) => return Ok(()),
+                Err(e) => {
+                    self.set_error_status(format!("Failed to start redirector: {e}"))
+                        .await;
+                }
             }
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }

--- a/proxy_agent/src/redirector/windows.rs
+++ b/proxy_agent/src/redirector/windows.rs
@@ -34,8 +34,6 @@ impl Default for BpfObject {
 impl super::Redirector {
     pub fn initialized(&self) -> Result<()> {
         if !bpf_api::ebpf_api_is_loaded() {
-            // self.set_error_status("Failed to load eBPF API.".to_string())
-            //    .await;
             return Err(Error::Bpf(BpfErrorType::GetBpfApi));
         }
         Ok(())

--- a/proxy_agent/src/redirector/windows/bpf_api.rs
+++ b/proxy_agent/src/redirector/windows/bpf_api.rs
@@ -11,7 +11,7 @@ use crate::common::{
 };
 use libloading::{Library, Symbol};
 use once_cell::sync::Lazy;
-use proxy_agent_shared::misc_helpers;
+use proxy_agent_shared::{logger::LoggerLevel, misc_helpers, telemetry::event_logger};
 use std::env;
 use std::ffi::{c_char, c_int, c_uint, c_void, CString};
 use std::path::PathBuf;
@@ -37,7 +37,13 @@ fn init_ebpf_lib() -> Option<Library> {
             return Some(ebpf_lib);
         }
         Err(e) => {
-            logger::write_warning(format!("{}", e));
+            event_logger::write_event(
+                LoggerLevel::Error,
+                format!("{}", e),
+                "load_ebpf_api",
+                "redirector",
+                logger::AGENT_LOGGER_KEY,
+            );
         }
     }
 
@@ -47,7 +53,13 @@ fn init_ebpf_lib() -> Option<Library> {
             return Some(ebpf_lib);
         }
         Err(e) => {
-            logger::write_warning(format!("{}", e));
+            event_logger::write_event(
+                LoggerLevel::Warn,
+                format!("{}", e),
+                "load_ebpf_api",
+                "redirector",
+                logger::AGENT_LOGGER_KEY,
+            );
         }
     }
 

--- a/proxy_agent/src/shared_state/provision_wrapper.rs
+++ b/proxy_agent/src/shared_state/provision_wrapper.rs
@@ -73,8 +73,8 @@ impl ProvisionSharedState {
             let mut provision_state: ProvisionFlags = ProvisionFlags::NONE;
             // The flag to indicate if the event log threads are initialized
             let mut provision_event_log_threads_initialized: bool = false;
-            // It indicate the time ticks when GPA service provision is finished, 0 means not finished
-            let mut provision_finished_time_ticks: i128 = 0;
+            // It indicate the time_tick when GPA service provision is finished, 0 means not finished
+            let mut provision_finished_time_tick: i128 = 0;
             while let Some(action) = rx.recv().await {
                 match action {
                     ProvisionAction::UpdateState { state, response } => {
@@ -121,11 +121,11 @@ impl ProvisionSharedState {
                     }
                     ProvisionAction::SetProvisionFinished { finished, response } => {
                         if finished {
-                            provision_finished_time_ticks = misc_helpers::get_date_time_unix_nano();
+                            provision_finished_time_tick = misc_helpers::get_date_time_unix_nano();
                         } else {
-                            provision_finished_time_ticks = 0;
+                            provision_finished_time_tick = 0;
                         }
-                        if response.send(provision_finished_time_ticks).is_err() {
+                        if response.send(provision_finished_time_tick).is_err() {
                             logger::write_warning(
                                 "Failed to send response to ProvisionAction::SetProvisionFinished"
                                     .to_string(),
@@ -133,7 +133,7 @@ impl ProvisionSharedState {
                         }
                     }
                     ProvisionAction::GetProvisionFinished { response } => {
-                        if let Err(finished) = response.send(provision_finished_time_ticks) {
+                        if let Err(finished) = response.send(provision_finished_time_tick) {
                             logger::write_warning(format!(
                                 "Failed to send response to ProvisionAction::GetProvisionFinished with finished '{:?}'",
                                 finished
@@ -247,7 +247,7 @@ impl ProvisionSharedState {
     /// # Arguments
     /// * `finished` - bool, true means provision finished, false means provision not finished
     /// # Returns
-    /// * `i128` - the time ticks when the provision finished, 0 means not finished
+    /// * `i128` - the time_tick when the provision finished, 0 means not finished
     /// # Errors - SendError, RecvError
     pub async fn set_provision_finished(&self, finished: bool) -> Result<i128> {
         let (tx, rx) = oneshot::channel();
@@ -269,7 +269,7 @@ impl ProvisionSharedState {
 
     /// Get the provision finished state
     /// # Returns
-    ///   * `i128` - the time ticks when the provision finished, 0 means not finished
+    ///   * `i128` - the time_tick when the provision finished, 0 means not finished
     /// # Errors - SendError, RecvError
     pub async fn get_provision_finished(&self) -> Result<i128> {
         let (tx, rx) = oneshot::channel();

--- a/proxy_agent/src/shared_state/provision_wrapper.rs
+++ b/proxy_agent/src/shared_state/provision_wrapper.rs
@@ -32,6 +32,7 @@ use crate::common::error::Error;
 use crate::common::logger;
 use crate::common::result::Result;
 use crate::provision::ProvisionFlags;
+use proxy_agent_shared::misc_helpers;
 use tokio::sync::{mpsc, oneshot};
 
 enum ProvisionAction {
@@ -54,10 +55,10 @@ enum ProvisionAction {
     },
     SetProvisionFinished {
         finished: bool,
-        response: oneshot::Sender<bool>,
+        response: oneshot::Sender<i128>,
     },
     GetProvisionFinished {
-        response: oneshot::Sender<bool>,
+        response: oneshot::Sender<i128>,
     },
 }
 
@@ -72,8 +73,8 @@ impl ProvisionSharedState {
             let mut provision_state: ProvisionFlags = ProvisionFlags::NONE;
             // The flag to indicate if the event log threads are initialized
             let mut provision_event_log_threads_initialized: bool = false;
-            // The flag to indicate if the GPA service provision is finished
-            let mut provision_finished: bool = false;
+            // It indicate the time ticks when GPA service provision is finished, 0 means not finished
+            let mut provision_finished_time_ticks: i128 = 0;
             while let Some(action) = rx.recv().await {
                 match action {
                     ProvisionAction::UpdateState { state, response } => {
@@ -119,8 +120,12 @@ impl ProvisionSharedState {
                         }
                     }
                     ProvisionAction::SetProvisionFinished { finished, response } => {
-                        provision_finished = finished;
-                        if response.send(finished).is_err() {
+                        if finished {
+                            provision_finished_time_ticks = misc_helpers::get_date_time_unix_nano();
+                        } else {
+                            provision_finished_time_ticks = 0;
+                        }
+                        if response.send(provision_finished_time_ticks).is_err() {
                             logger::write_warning(
                                 "Failed to send response to ProvisionAction::SetProvisionFinished"
                                     .to_string(),
@@ -128,7 +133,7 @@ impl ProvisionSharedState {
                         }
                     }
                     ProvisionAction::GetProvisionFinished { response } => {
-                        if let Err(finished) = response.send(provision_finished) {
+                        if let Err(finished) = response.send(provision_finished_time_ticks) {
                             logger::write_warning(format!(
                                 "Failed to send response to ProvisionAction::GetProvisionFinished with finished '{:?}'",
                                 finished
@@ -238,7 +243,13 @@ impl ProvisionSharedState {
         })
     }
 
-    pub async fn set_provision_finished(&self, finished: bool) -> Result<bool> {
+    /// Set the provision finished state
+    /// # Arguments
+    /// * `finished` - bool, true means provision finished, false means provision not finished
+    /// # Returns
+    /// * `i128` - the time ticks when the provision finished, 0 means not finished
+    /// # Errors - SendError, RecvError
+    pub async fn set_provision_finished(&self, finished: bool) -> Result<i128> {
         let (tx, rx) = oneshot::channel();
         self.0
             .send(ProvisionAction::SetProvisionFinished {
@@ -256,7 +267,11 @@ impl ProvisionSharedState {
             .map_err(|e| Error::RecvError("ProvisionAction::SetProvisionFinished".to_string(), e))
     }
 
-    pub async fn get_provision_finished(&self) -> Result<bool> {
+    /// Get the provision finished state
+    /// # Returns
+    ///   * `i128` - the time ticks when the provision finished, 0 means not finished
+    /// # Errors - SendError, RecvError
+    pub async fn get_provision_finished(&self) -> Result<i128> {
         let (tx, rx) = oneshot::channel();
         self.0
             .send(ProvisionAction::GetProvisionFinished { response: tx })


### PR DESCRIPTION
**provision state changes: **
- Update provision finished state from bool to i128 for finished timetick
- added new struct ProvisionStateInternal to represent the internal state of provision within GPA service

**provision query changes: **
- add sub mod provision_query for --status [--wait seconds] command related business
-  add query_timetick to the request header
- add notify header to the first request header

**proxy http server changes: **
- report provision finished when finished timetick is later than the query timetick or secure channel latched
- notify key_keeper module if request contains notify header and report provision finished is false

key_keeper changes:
- reset secure channel state when reset key_latch state
- reset provision_timeup when reset the provision start timer
- report key_latched ready to try update the provision finished time ticks