### PR TITLE
Perf Changes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -75,7 +75,6 @@ jobs:
                 build-essential \
                 linux-tools-$(uname -r) \
                 linux-tools-common \
-                linux-tools-generic \
                 rpm \
                 musl-tools \
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -292,7 +292,6 @@ jobs:
                   build-essential \
                   linux-tools-$(uname -r) \
                   linux-tools-common \
-                  linux-tools-generic \
                   rpm \
                   musl-tools \
                   libssl-dev \
@@ -464,7 +463,6 @@ jobs:
                   build-essential \
                   linux-tools-$(uname -r) \
                   linux-tools-common \
-                  linux-tools-generic \
                   rpm \
                   musl-tools \
                   gcc-aarch64-linux-gnu \

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,5 +32,8 @@
     ],
     "vscode-nmake-tools.workspaceBuildDirectories": [
         "."
-    ]
+    ],
+    "chat.tools.terminal.autoApprove": {
+        "./build-linux.sh": true
+    }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "serde-xml-rs",
  "serde_derive",
  "serde_json",
+ "socket2",
  "static_vcruntime",
  "sysinfo",
  "thiserror",

--- a/proxy_agent/Cargo.toml
+++ b/proxy_agent/Cargo.toml
@@ -19,6 +19,7 @@ bitflags = "2.6.0"            # support bitflag enum
 regex = "1.11"                # match process name in cmdline
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "time",  "net", "macros", "sync"] }
 tokio-util = "0.7.11"
+socket2 = "0.5"               # Set socket options without tokio/std conversion
 http = "1.1.0"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["server", "http1", "client"] }

--- a/proxy_agent/src/common/config.rs
+++ b/proxy_agent/src/common/config.rs
@@ -122,39 +122,51 @@ impl Default for Config {
             config_file_full_path = misc_helpers::get_current_exe_dir();
             config_file_full_path.push(CONFIG_FILE_NAME);
         }
-        Config::from_json_file(config_file_full_path)
+        let mut config = misc_helpers::json_read_from_file::<Config>(&config_file_full_path)
+            .unwrap_or_else(|_| {
+                panic!(
+                    "Error in reading Config from Json file: {}",
+                    misc_helpers::path_to_string(&config_file_full_path)
+                )
+            });
+        config.resolve_env_variables();
+        config
     }
 }
 
 impl Config {
+    /// Load config from a specific JSON file path (primarily for testing)
     pub fn from_json_file(file_path: PathBuf) -> Self {
-        misc_helpers::json_read_from_file::<Config>(&file_path).unwrap_or_else(|_| {
-            panic!(
-                "Error in reading Config from Json file: {}",
-                misc_helpers::path_to_string(&file_path)
-            )
-        })
+        let mut config =
+            misc_helpers::json_read_from_file::<Config>(&file_path).unwrap_or_else(|_| {
+                panic!(
+                    "Error in reading Config from Json file: {}",
+                    misc_helpers::path_to_string(&file_path)
+                )
+            });
+        config.resolve_env_variables();
+        config
     }
 
-    pub fn get_log_folder(&self) -> String {
-        match misc_helpers::resolve_env_variables(&self.logFolder) {
-            Ok(val) => val,
-            Err(_) => self.logFolder.clone(),
-        }
+    /// Resolve environment variables in path fields once during construction
+    /// This allows us to keep the rest of the code simple without worrying about env vars,
+    /// and also ensures that we only pay the cost of resolving env vars once at startup rather than on every access.
+    fn resolve_env_variables(&mut self) {
+        self.logFolder = misc_helpers::resolve_env_variables(&self.logFolder);
+        self.eventFolder = misc_helpers::resolve_env_variables(&self.eventFolder);
+        self.latchKeyFolder = misc_helpers::resolve_env_variables(&self.latchKeyFolder);
     }
 
-    pub fn get_event_folder(&self) -> String {
-        match misc_helpers::resolve_env_variables(&self.eventFolder) {
-            Ok(val) => val,
-            Err(_) => self.eventFolder.clone(),
-        }
+    pub fn get_log_folder(&self) -> &str {
+        &self.logFolder
     }
 
-    pub fn get_latch_key_folder(&self) -> String {
-        match misc_helpers::resolve_env_variables(&self.latchKeyFolder) {
-            Ok(val) => val,
-            Err(_) => self.latchKeyFolder.clone(),
-        }
+    pub fn get_event_folder(&self) -> &str {
+        &self.eventFolder
+    }
+
+    pub fn get_latch_key_folder(&self) -> &str {
+        &self.latchKeyFolder
     }
 
     pub fn get_monitor_interval(&self) -> u64 {
@@ -231,19 +243,19 @@ mod tests {
         let config = create_config_file(config_file_path);
 
         assert_eq!(
-            r#"C:\logFolderName"#.to_string(),
+            r#"C:\logFolderName"#,
             config.get_log_folder(),
             "Log Folder mismatch"
         );
 
         assert_eq!(
-            r#"C:\eventFolderName"#.to_string(),
+            r#"C:\eventFolderName"#,
             config.get_event_folder(),
             "Event Folder mismatch"
         );
 
         assert_eq!(
-            r#"C:\latchKeyFolderName"#.to_string(),
+            r#"C:\latchKeyFolderName"#,
             config.get_latch_key_folder(),
             "Latch Key Folder mismatch"
         );

--- a/proxy_agent/src/common/logger.rs
+++ b/proxy_agent/src/common/logger.rs
@@ -43,14 +43,14 @@ fn log(log_level: LoggerLevel, message: String) {
 
 #[cfg(not(windows))]
 pub fn write_serial_console_log(message: String) {
-    use proxy_agent_shared::misc_helpers;
+    use proxy_agent_shared::{current_info, misc_helpers};
     use std::io::Write;
 
     let message = format!(
         "{} {}_{}({}) - {}\n",
         misc_helpers::get_date_time_string_with_milliseconds(),
         env!("CARGO_PKG_NAME"),
-        misc_helpers::get_current_version(),
+        current_info::get_current_exe_version(),
         std::process::id(),
         message
     );

--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -1032,7 +1032,7 @@ mod tests {
         match fs::remove_dir_all(&temp_test_path) {
             Ok(_) => {}
             Err(e) => {
-                print!("Failed to remove_dir_all with error {}.", e);
+                eprintln!("Failed to remove_dir_all with error {}.", e);
             }
         }
 
@@ -1040,11 +1040,9 @@ mod tests {
         // start wire_server listener
         let ip = "127.0.0.1";
         let port = 8081u16;
-        tokio::spawn(server_mock::start(
-            ip.to_string(),
-            port,
-            cancellation_token.clone(),
-        ));
+        let port = server_mock::start(ip.to_string(), port, cancellation_token.clone())
+            .await
+            .unwrap();
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         // start with disabled secure channel state

--- a/proxy_agent/src/key_keeper.rs
+++ b/proxy_agent/src/key_keeper.rs
@@ -10,16 +10,16 @@
 //! use proxy_agent::key_keeper;
 //! use proxy_agent::shared_state::SharedState;
 //! use std::sync::{Arc, Mutex};
-//! use hyper::Uri;
 //! use std::path::PathBuf;
 //! use std::time::Duration;
 //!
 //! let shared_state = SharedState::start_all();
-//! let base_url = "http://127:0.0.1:8081/";
+//! let host = "127.0.0.1".to_string();
+//! let port = 8081u16;
 //! let key_dir = PathBuf::from("path");
+//! let status_dir = PathBuf::from("status");
 //! let interval = Duration::from_secs(10);
-//! let config_start_redirector = false;
-//! let key_keeper = key_keeper::KeyKeeper::new(base_url.parse().unwrap(), key_dir, interval, config_start_redirector, &shared_state);
+//! let key_keeper = key_keeper::KeyKeeper::new(host, port, key_dir, status_dir, interval, &shared_state);
 //! tokio::spawn(key_keeper.poll_secure_channel_status());
 //! ```
 
@@ -40,7 +40,6 @@ use crate::shared_state::provision_wrapper::ProvisionSharedState;
 use crate::shared_state::redirector_wrapper::RedirectorSharedState;
 use crate::shared_state::{EventThreadsSharedState, SharedState};
 use crate::{acl, redirector};
-use hyper::Uri;
 use proxy_agent_shared::common_state::CommonState;
 use proxy_agent_shared::logger::LoggerLevel;
 use proxy_agent_shared::misc_helpers;
@@ -64,8 +63,10 @@ const DELAY_START_EVENT_THREADS_IN_MILLISECONDS: u128 = 60000; // 1 minute
 
 #[derive(Clone)]
 pub struct KeyKeeper {
-    /// base_url: the WireServer endpoint to poll the secure channel status
-    base_url: Uri,
+    /// host: the WireServer host to poll the secure channel status
+    host: String,
+    /// port: the WireServer port to poll the secure channel status
+    port: u16,
     /// key_dir: the folder to save the key details
     key_dir: PathBuf,
     /// status_dir: the folder to log the access control rule details
@@ -101,14 +102,16 @@ enum WakeReason {
 
 impl KeyKeeper {
     pub fn new(
-        base_url: Uri,
+        host: String,
+        port: u16,
         key_dir: PathBuf,
         status_dir: PathBuf,
         interval: Duration,
         shared_state: &SharedState,
     ) -> Self {
         KeyKeeper {
-            base_url,
+            host,
+            port,
             key_dir,
             status_dir,
             interval,
@@ -247,7 +250,7 @@ impl KeyKeeper {
                 .await;
             started_event_threads = self.handle_event_threads_start(started_event_threads).await;
 
-            let status = match key::get_status(&self.base_url).await {
+            let status = match key::get_status(&self.host, self.port).await {
                 Ok(s) => s,
                 Err(e) => {
                     self.update_status_message(format!("Failed to get key status - {e}"), true)
@@ -629,7 +632,7 @@ impl KeyKeeper {
     /// Acquire key from server, persist it, and attest it
     /// Returns true if successful, false if should continue to next iteration
     async fn acquire_key_from_server(&self) -> bool {
-        let key = match key::acquire_key(&self.base_url).await {
+        let key = match key::acquire_key(&self.host, self.port).await {
             Ok(k) => k,
             Err(e) => {
                 self.update_status_message(format!("Failed to acquire key details: {e:?}"), true)
@@ -660,7 +663,7 @@ impl KeyKeeper {
         }
 
         // attest the key
-        match key::attest_key(&self.base_url, &key).await {
+        match key::attest_key(&self.host, self.port, &key).await {
             Ok(()) => {
                 // update in memory
                 if let Err(e) = self.update_key_to_shared_state(key.clone()).await {
@@ -1051,7 +1054,8 @@ mod tests {
         // start poll_secure_channel_status
         let cloned_keys_dir = keys_dir.to_path_buf();
         let key_keeper = KeyKeeper {
-            base_url: (format!("http://{}:{}/", ip, port)).parse().unwrap(),
+            host: ip.to_string(),
+            port,
             key_dir: cloned_keys_dir.clone(),
             status_dir: cloned_keys_dir.clone(),
             interval: Duration::from_millis(10),

--- a/proxy_agent/src/key_keeper/key.rs
+++ b/proxy_agent/src/key_keeper/key.rs
@@ -720,40 +720,23 @@ impl Display for KeyAction {
 const STATUS_URL: &str = "/secure-channel/status";
 const KEY_URL: &str = "/secure-channel/key";
 
-pub async fn get_status(base_url: &Uri) -> Result<KeyStatus> {
-    let (host, port) = hyper_client::host_port_from_uri(base_url)?;
-    let url = format!("http://{host}:{port}{STATUS_URL}");
-    let url: Uri = url.parse().map_err(|e| {
-        Error::Key(KeyErrorType::ParseKeyUrl(
-            base_url.to_string(),
-            STATUS_URL.to_string(),
-            e,
-        ))
-    })?;
+pub async fn get_status(host: &str, port: u16) -> Result<KeyStatus> {
+    let endpoint = hyper_client::HostEndpoint::new(host, port, STATUS_URL);
     let mut headers = HashMap::new();
     headers.insert(
         hyper_client::METADATA_HEADER.to_string(),
         "True ".to_string(),
     );
     let status: KeyStatus =
-        hyper_client::get(&url, &headers, None, None, logger::write_warning).await?;
+        hyper_client::get(&endpoint, &headers, None, None, logger::write_warning).await?;
     status.validate()?;
 
     Ok(status)
 }
 
-pub async fn acquire_key(base_url: &Uri) -> Result<Key> {
-    let (host, port) = hyper_client::host_port_from_uri(base_url)?;
-    let url = format!("http://{host}:{port}{KEY_URL}");
-    let url: Uri = url.parse().map_err(|e| {
-        Error::Key(KeyErrorType::ParseKeyUrl(
-            base_url.to_string(),
-            KEY_URL.to_string(),
-            e,
-        ))
-    })?;
+pub async fn acquire_key(host: &str, port: u16) -> Result<Key> {
+    let endpoint = hyper_client::HostEndpoint::new(host, port, KEY_URL);
 
-    let (host, port) = hyper_client::host_port_from_uri(&url)?;
     let mut headers = HashMap::new();
     headers.insert(
         hyper_client::METADATA_HEADER.to_string(),
@@ -763,21 +746,26 @@ pub async fn acquire_key(base_url: &Uri) -> Result<Key> {
     let body = r#"{"authorizationScheme": "Azure-HMAC-SHA256"}"#.to_string();
     let request = hyper_client::build_request(
         hyper::Method::POST,
-        &url,
+        &endpoint,
         &headers,
         Some(body.as_bytes()),
         None,
         None,
     )?;
 
-    let response = hyper_client::send_request(&host, port, request, logger::write_warning)
-        .await
-        .map_err(|e| {
-            Error::Key(KeyErrorType::SendKeyRequest(
-                format!("{}", KeyAction::Acquire),
-                e.to_string(),
-            ))
-        })?;
+    let response = hyper_client::send_request(
+        &endpoint.host,
+        endpoint.port,
+        request,
+        logger::write_warning,
+    )
+    .await
+    .map_err(|e| {
+        Error::Key(KeyErrorType::SendKeyRequest(
+            format!("{}", KeyAction::Acquire),
+            e.to_string(),
+        ))
+    })?;
 
     if response.status() != StatusCode::OK {
         return Err(Error::Key(KeyErrorType::KeyResponse(
@@ -790,16 +778,10 @@ pub async fn acquire_key(base_url: &Uri) -> Result<Key> {
         .map_err(Error::ProxyAgentSharedError)
 }
 
-pub async fn attest_key(base_url: &Uri, key: &Key) -> Result<()> {
+pub async fn attest_key(host: &str, port: u16, key: &Key) -> Result<()> {
     // secure-channel/key/{key_guid}/key-attestation
-    let (host, port) = hyper_client::host_port_from_uri(base_url)?;
-    let url = format!(
-        "http://{}:{}{}/{}/key-attestation",
-        host, port, KEY_URL, key.guid
-    );
-    let url: Uri = url
-        .parse()
-        .map_err(|e| Error::Key(KeyErrorType::ParseKeyUrl(base_url.to_string(), url, e)))?;
+    let path = format!("{}/{}/key-attestation", KEY_URL, key.guid);
+    let endpoint = hyper_client::HostEndpoint::new(host, port, &path);
 
     let mut headers = HashMap::new();
     headers.insert(
@@ -808,21 +790,26 @@ pub async fn attest_key(base_url: &Uri, key: &Key) -> Result<()> {
     );
     let request = hyper_client::build_request(
         Method::POST,
-        &url,
+        &endpoint,
         &headers,
         None,
         Some(key.guid.to_string()),
         Some(key.key.to_string()),
     )?;
 
-    let response = hyper_client::send_request(&host, port, request, logger::write_warning)
-        .await
-        .map_err(|e| {
-            Error::Key(KeyErrorType::SendKeyRequest(
-                format!("{}", KeyAction::Attest),
-                e.to_string(),
-            ))
-        })?;
+    let response = hyper_client::send_request(
+        &endpoint.host,
+        endpoint.port,
+        request,
+        logger::write_warning,
+    )
+    .await
+    .map_err(|e| {
+        Error::Key(KeyErrorType::SendKeyRequest(
+            format!("{}", KeyAction::Attest),
+            e.to_string(),
+        ))
+    })?;
 
     if response.status() != StatusCode::OK {
         return Err(Error::Key(KeyErrorType::KeyResponse(

--- a/proxy_agent/src/main.rs
+++ b/proxy_agent/src/main.rs
@@ -15,7 +15,7 @@ use common::cli::{Commands, CLI};
 use common::constants;
 use common::helpers;
 use provision::provision_query::ProvisionQuery;
-use proxy_agent_shared::misc_helpers;
+use proxy_agent_shared::current_info;
 use shared_state::SharedState;
 use std::{process, time::Duration};
 
@@ -48,7 +48,7 @@ async fn main() {
     let _time = helpers::get_elapsed_time_in_millisec();
 
     if CLI.version {
-        println!("{}", misc_helpers::get_current_version());
+        println!("{}", current_info::get_current_exe_version());
         return;
     }
 

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -382,6 +382,19 @@ pub async fn start_event_threads(event_threads_shared_state: EventThreadsSharedS
         }
     });
     tokio::spawn({
+        let event_reader = EventReader::new(
+            config::get_events_dir(),
+            event_threads_shared_state.common_state.clone(),
+            "ProxyAgent".to_string(),
+            "MicrosoftAzureGuestProxyAgent".to_string(),
+        );
+        async move {
+            event_reader
+                .start_extension_status_event_processor(true, Some(Duration::from_secs(60)))
+                .await;
+        }
+    });
+    tokio::spawn({
         let event_sender = EventSender::new(event_threads_shared_state.common_state.clone());
         async move {
             event_sender.start(None, None).await;

--- a/proxy_agent/src/provision.rs
+++ b/proxy_agent/src/provision.rs
@@ -648,16 +648,11 @@ pub mod provision_query {
         //  bool - true provision finished; false provision not finished
         //  String - provision error message, empty means provision success or provision failed.
         async fn get_current_provision_status(&self, notify: bool) -> Result<ProvisionState> {
-            let provision_url: String = format!(
-                "http://{}:{}{}",
-                Ipv4Addr::LOCALHOST,
+            let endpoint = hyper_client::HostEndpoint::new(
+                Ipv4Addr::LOCALHOST.to_string(),
                 self.port,
-                PROVISION_URL_PATH
+                PROVISION_URL_PATH,
             );
-
-            let provision_url: hyper::Uri = provision_url
-                .parse::<hyper::Uri>()
-                .map_err(|e| Error::ParseUrl(provision_url, e.to_string()))?;
 
             let mut headers = HashMap::new();
             headers.insert(
@@ -671,7 +666,7 @@ pub mod provision_query {
             if notify {
                 headers.insert(constants::NOTIFY_HEADER.to_string(), "true".to_string());
             }
-            hyper_client::get(&provision_url, &headers, None, None, logger::write_warning)
+            hyper_client::get(&endpoint, &headers, None, None, logger::write_warning)
                 .await
                 .map_err(Error::ProxyAgentSharedError)
         }

--- a/proxy_agent/src/proxy.rs
+++ b/proxy_agent/src/proxy.rs
@@ -96,9 +96,9 @@ async fn get_user(
 /// Get process information (executable path and command line) for the given process ID.
 /// Reads directly from the /proc filesystem on Linux for better performance.
 /// Returns (executable path, command line). If the process information cannot be retrieved, returns (empty path, "undefined" command line).
-/// Remarks: both /proc/{pid}/exe and /proc/{pid}/cmdline are universally supported across all Linux distributions since kernel 1.0 
-/// Remarks: Donot use sysinfo::System::refresh_process_specifics(pid, refresh_kind) to get this information, 
-///     as it reads all files from /proc/{pid}/* and Create Process struct with all fields, 
+/// Remarks: both /proc/{pid}/exe and /proc/{pid}/cmdline are universally supported across all Linux distributions since kernel 1.0
+/// Remarks: Donot use sysinfo::System::refresh_process_specifics(pid, refresh_kind) to get this information,
+///     as it reads all files from /proc/{pid}/* and Create Process struct with all fields,
 ///     which is very inefficient when we only need the executable path and command line.
 #[cfg(not(windows))]
 fn get_process_info(process_id: u32) -> (PathBuf, String) {

--- a/proxy_agent/src/proxy.rs
+++ b/proxy_agent/src/proxy.rs
@@ -46,9 +46,6 @@ use crate::shared_state::proxy_server_wrapper::ProxyServerSharedState;
 use serde_derive::{Deserialize, Serialize};
 use std::{ffi::OsString, net::IpAddr, path::PathBuf};
 
-#[cfg(not(windows))]
-use sysinfo::{Pid, ProcessRefreshKind, RefreshKind, System, UpdateKind};
-
 #[derive(Serialize, Deserialize, Clone)]
 #[allow(non_snake_case)]
 pub struct Claims {
@@ -96,26 +93,36 @@ async fn get_user(
     }
 }
 
+/// Get process information (executable path and command line) for the given process ID.
+/// Reads directly from the /proc filesystem on Linux for better performance.
+/// Returns (executable path, command line). If the process information cannot be retrieved, returns (empty path, "undefined" command line).
+/// Remarks: both /proc/{pid}/exe and /proc/{pid}/cmdline are universally supported across all Linux distributions since kernel 1.0 
+/// Remarks: Donot use sysinfo::System::refresh_process_specifics(pid, refresh_kind) to get this information, 
+///     as it reads all files from /proc/{pid}/* and Create Process struct with all fields, 
+///     which is very inefficient when we only need the executable path and command line.
 #[cfg(not(windows))]
 fn get_process_info(process_id: u32) -> (PathBuf, String) {
-    let mut process_name = PathBuf::default();
-    let mut process_cmd_line = UNDEFINED.to_string();
+    // Read process info directly from /proc/{pid}/ instead of scanning all processes.
+    // This is much more efficient than using sysinfo::System which scans the entire /proc filesystem.
 
-    let pid = Pid::from_u32(process_id);
-    let sys = System::new_with_specifics(
-        RefreshKind::new().with_processes(
-            ProcessRefreshKind::new()
-                .with_cmd(UpdateKind::Always)
-                .with_exe(UpdateKind::Always),
-        ),
-    );
-    if let Some(p) = sys.process(pid) {
-        process_name = match p.exe() {
-            Some(path) => path.to_path_buf(),
-            None => PathBuf::default(),
-        };
-        process_cmd_line = p.cmd().join(" ");
-    }
+    // Get executable path from /proc/{pid}/exe symlink
+    let exe_path = format!("/proc/{}/exe", process_id);
+    let process_name = std::fs::read_link(&exe_path).unwrap_or_default();
+
+    // Get command line from /proc/{pid}/cmdline (null-separated arguments)
+    let cmdline_path = format!("/proc/{}/cmdline", process_id);
+    let process_cmd_line = match std::fs::read(&cmdline_path) {
+        Ok(bytes) => {
+            // cmdline is null-separated, convert to space-separated string
+            bytes
+                .split(|&b| b == 0)
+                .filter(|s| !s.is_empty())
+                .map(|s| String::from_utf8_lossy(s).into_owned())
+                .collect::<Vec<String>>()
+                .join(" ")
+        }
+        Err(_) => UNDEFINED.to_string(),
+    };
 
     (process_name, process_cmd_line)
 }

--- a/proxy_agent/src/proxy.rs
+++ b/proxy_agent/src/proxy.rs
@@ -90,9 +90,8 @@ async fn get_user(
         Ok(user)
     } else {
         let user = User::from_logon_id(logon_id)?;
-        if let Err(e) = proxy_server_shared_state.add_user(user.clone()).await {
-            println!("Failed to add user: {e} to cache");
-        }
+        // Ignore cache add failures - non-critical
+        let _ = proxy_server_shared_state.add_user(user.clone()).await;
         Ok(user)
     }
 }
@@ -170,26 +169,19 @@ impl Process {
             };
 
             let options = PROCESS_QUERY_INFORMATION | PROCESS_VM_READ;
-            let handler = proxy_agent_shared::windows::get_process_handler(pid, options)
-                .unwrap_or_else(|e| {
-                    println!("Failed to get process handler: {e}");
-                    0
-                });
-            let base_info = windows::query_basic_process_info(handler);
-            match base_info {
-                Ok(_) => {
-                    process_full_path = windows::get_process_full_name(handler).unwrap_or_default();
-                    cmd = windows::get_process_cmd(handler).unwrap_or(UNDEFINED.to_string());
-                }
-                Err(e) => {
-                    process_full_path = PathBuf::default();
-                    cmd = UNDEFINED.to_string();
-                    println!("Failed to query basic process info: {e}");
-                }
-            }
-            // close the handle
-            if let Err(e) = proxy_agent_shared::windows::close_handler(handler) {
-                println!("Failed to close process handler: {e}");
+            let handler =
+                proxy_agent_shared::windows::get_process_handler(pid, options).unwrap_or(0);
+
+            if handler != 0 {
+                // Get process info directly - if either fails, the process may have exited
+                process_full_path = windows::get_process_full_name(handler).unwrap_or_default();
+                cmd = windows::get_process_cmd(handler).unwrap_or(UNDEFINED.to_string());
+                // close the handle - ignore errors as handle may be invalid
+                let _ = proxy_agent_shared::windows::close_handler(handler);
+            } else {
+                // Process may have exited or be inaccessible - this is expected
+                process_full_path = PathBuf::default();
+                cmd = UNDEFINED.to_string();
             }
         }
         #[cfg(not(windows))]
@@ -200,7 +192,7 @@ impl Process {
         }
 
         // redact the secrets in the command line
-        let cmd = proxy_agent_shared::secrets_redactor::redact_secrets(cmd);
+        let cmd = proxy_agent_shared::secrets_redactor::redact_secrets_string(cmd);
 
         let process_name = process_full_path
             .file_name()

--- a/proxy_agent/src/proxy/authorization_rules.rs
+++ b/proxy_agent/src/proxy/authorization_rules.rs
@@ -544,7 +544,7 @@ mod tests {
         match std::fs::remove_dir_all(&temp_test_path) {
             Ok(_) => {}
             Err(e) => {
-                print!("Failed to remove_dir_all with error {}.", e);
+                eprintln!("Failed to remove_dir_all with error {}.", e);
             }
         }
         misc_helpers::try_create_folder(&temp_test_path).unwrap();

--- a/proxy_agent/src/proxy/proxy_connection.rs
+++ b/proxy_agent/src/proxy/proxy_connection.rs
@@ -339,14 +339,14 @@ impl ConnectionLogger {
         // write to system log for connection logger explicitly,
         // as the connection logger only writes to file when the connection is dropped and,
         // connection logger file log does not write to system log implicitly.
-        logger_manager::write_system_log(logger_level, message.to_string());
+        logger_manager::write_system_log(logger_level, message.clone());
 
         if let Some(log_for_event) = crate::common::config::get_file_log_level_for_events() {
             if log_for_event >= logger_level {
                 // write to event
                 proxy_agent_shared::telemetry::event_logger::write_event_only(
                     logger_level,
-                    message.to_string(),
+                    message.clone(),
                     "ConnectionLogger",
                     "ProxyAgent",
                 );
@@ -360,11 +360,9 @@ impl ConnectionLogger {
             return;
         }
 
-        self.queue.push(format!(
-            "{}{}",
-            logger::get_log_header(logger_level),
-            message
-        ));
+        let mut msg = logger::get_log_header(logger_level);
+        msg.push_str(&message);
+        self.queue.push(msg);
     }
 }
 

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -253,24 +253,20 @@ impl ProxyServer {
         tokio::spawn({
             let cloned_proxy_server = self.clone();
             async move {
-                let (stream, _cloned_std_stream) =
-                    match Self::set_stream_read_time_out(stream, &mut tcp_connection_logger) {
-                        Ok((stream, cloned_std_stream)) => (stream, cloned_std_stream),
-                        Err(e) => {
-                            tcp_connection_logger.write(
-                                LoggerLevel::Error,
-                                format!("Failed to set stream read timeout: {e}"),
-                            );
-                            return;
-                        }
-                    };
+                // Get raw socket ID before any conversion (Windows only)
+                #[cfg(windows)]
+                let raw_socket_id = Self::get_stream_raw_socket_id(&stream);
+
+                // Set read timeout directly on the socket without conversion
+                Self::set_stream_read_time_out(&stream, &mut tcp_connection_logger);
+
                 let tcp_connection_context = TcpConnectionContext::new(
                     tcp_connection_id,
                     client_addr,
                     cloned_proxy_server.redirector_shared_state.clone(),
                     cloned_proxy_server.proxy_server_shared_state.clone(),
                     #[cfg(windows)]
-                    ProxyServer::get_stream_rocket_id(&_cloned_std_stream),
+                    raw_socket_id,
                 )
                 .await;
 
@@ -324,46 +320,30 @@ impl ProxyServer {
     }
 
     #[cfg(windows)]
-    fn get_stream_rocket_id(stream: &std::net::TcpStream) -> usize {
+    fn get_stream_raw_socket_id(stream: &TcpStream) -> usize {
         use std::os::windows::io::AsRawSocket;
         stream.as_raw_socket() as usize
     }
 
-    // Set the read timeout for the stream
-    fn set_stream_read_time_out(
-        stream: TcpStream,
-        connection_logger: &mut ConnectionLogger,
-    ) -> Result<(TcpStream, std::net::TcpStream)> {
-        // Convert the stream to a std stream
-        let std_stream = stream.into_std().map_err(|e| {
-            Error::Io(
-                "Failed to convert Tokio stream into std equivalent".to_string(),
-                e,
-            )
-        })?;
+    #[cfg(not(windows))]
+    fn get_stream_raw_socket_id(stream: &TcpStream) -> usize {
+        use std::os::unix::io::AsRawFd;
+        stream.as_raw_fd() as usize
+    }
 
-        // Set the read timeout
-        if let Err(e) = std_stream.set_read_timeout(Some(std::time::Duration::from_secs(10))) {
+    // Set the read timeout for the stream without converting to std
+    // socket2 crate alreasdy used by tokio internally
+    // Uses socket2::SockRef to set socket options directly on the tokio stream
+    fn set_stream_read_time_out(stream: &TcpStream, connection_logger: &mut ConnectionLogger) {
+        use socket2::SockRef;
+
+        let sock_ref = SockRef::from(stream);
+        if let Err(e) = sock_ref.set_read_timeout(Some(std::time::Duration::from_secs(10))) {
             connection_logger.write(
                 LoggerLevel::Warn,
                 format!("Failed to set read timeout: {e}"),
             );
         }
-
-        // Clone the stream for the service_fn
-        let cloned_std_stream = std_stream
-            .try_clone()
-            .map_err(|e| Error::Io("Failed to clone TCP stream".to_string(), e))?;
-
-        // Convert the std stream back
-        let tokio_tcp_stream = TcpStream::from_std(std_stream).map_err(|e| {
-            Error::Io(
-                "Failed to convert std stream into Tokio equivalent".to_string(),
-                e,
-            )
-        })?;
-
-        Ok((tokio_tcp_stream, cloned_std_stream))
     }
 
     async fn handle_new_http_request(
@@ -1071,10 +1051,10 @@ mod tests {
         let sleep_duration = Duration::from_millis(100);
         tokio::time::sleep(sleep_duration).await;
 
-        let url: hyper::Uri = format!("http://{}:{}/", host, port).parse().unwrap();
+        let endpoint = hyper_client::HostEndpoint::new(host, port, "/");
         let request = hyper_client::build_request(
             Method::GET,
-            &url,
+            &endpoint,
             &HashMap::new(),
             None,
             key_keeper_shared_state
@@ -1111,12 +1091,10 @@ mod tests {
         );
 
         // test with traversal characters
-        let url: hyper::Uri = format!("http://{}:{}/test/../", host, port)
-            .parse()
-            .unwrap();
+        let endpoint = hyper_client::HostEndpoint::new(host, port, "/test/../");
         let request = hyper_client::build_request(
             Method::GET,
-            &url,
+            &endpoint,
             &HashMap::new(),
             None,
             key_keeper_shared_state
@@ -1142,7 +1120,7 @@ mod tests {
         let body = vec![88u8; super::REQUEST_BODY_LOW_LIMIT_SIZE + 1];
         let request = hyper_client::build_request(
             Method::POST,
-            &url,
+            &endpoint,
             &HashMap::new(),
             Some(body.as_slice()),
             key_keeper_shared_state

--- a/proxy_agent/src/proxy/proxy_server.rs
+++ b/proxy_agent/src/proxy/proxy_server.rs
@@ -325,12 +325,6 @@ impl ProxyServer {
         stream.as_raw_socket() as usize
     }
 
-    #[cfg(not(windows))]
-    fn get_stream_raw_socket_id(stream: &TcpStream) -> usize {
-        use std::os::unix::io::AsRawFd;
-        stream.as_raw_fd() as usize
-    }
-
     // Set the read timeout for the stream without converting to std
     // socket2 crate alreasdy used by tokio internally
     // Uses socket2::SockRef to set socket options directly on the tokio stream

--- a/proxy_agent/src/proxy/windows.rs
+++ b/proxy_agent/src/proxy/windows.rs
@@ -24,7 +24,6 @@ use windows_sys::Win32::System::ProcessStatus::{
     K32GetModuleBaseNameW,   // kernel32.dll
     K32GetModuleFileNameExW, // kernel32.dll
 };
-use windows_sys::Win32::System::Threading::PROCESS_BASIC_INFORMATION;
 
 const LG_INCLUDE_INDIRECT: u32 = 1u32;
 const MAX_PREFERRED_LENGTH: u32 = 4294967295u32;
@@ -239,80 +238,61 @@ const MAX_PATH: usize = 260;
 const STATUS_BUFFER_OVERFLOW: NTSTATUS = -2147483643;
 const STATUS_BUFFER_TOO_SMALL: NTSTATUS = -1073741789;
 const STATUS_INFO_LENGTH_MISMATCH: NTSTATUS = -1073741820;
-const PROCESS_BASIC_INFORMATION_CLASS: PROCESSINFOCLASS = 0;
 const PROCESS_COMMAND_LINE_INFORMATION_CLASS: PROCESSINFOCLASS = 60;
 
-pub fn query_basic_process_info(handler: isize) -> Result<PROCESS_BASIC_INFORMATION> {
-    unsafe {
-        let mut process_basic_information = std::mem::zeroed::<PROCESS_BASIC_INFORMATION>();
-        let mut return_length = 0;
-        let status: NTSTATUS = NtQueryInformationProcess(
-            handler,
-            PROCESS_BASIC_INFORMATION_CLASS,
-            &mut process_basic_information as *mut _ as *mut _,
-            std::mem::size_of::<PROCESS_BASIC_INFORMATION>() as u32,
-            &mut return_length,
-        );
-
-        if status != 0 {
-            return Err(Error::WindowsApi(WindowsApiErrorType::WindowsOsError(
-                std::io::Error::from_raw_os_error(status),
-            )));
-        }
-        Ok(process_basic_information)
-    }
-}
-
 pub fn get_process_cmd(handler: isize) -> Result<String> {
-    unsafe {
-        let mut return_length = 0;
-        let status: NTSTATUS = NtQueryInformationProcess(
+    let mut return_length = 0;
+    let status: NTSTATUS = unsafe {
+        NtQueryInformationProcess(
             handler,
             PROCESS_COMMAND_LINE_INFORMATION_CLASS,
             null_mut(),
             0,
             &mut return_length as *mut _,
-        );
+        )
+    };
 
-        if status != STATUS_BUFFER_OVERFLOW
-            && status != STATUS_BUFFER_TOO_SMALL
-            && status != STATUS_INFO_LENGTH_MISMATCH
-        {
-            return Err(Error::WindowsApi(WindowsApiErrorType::WindowsOsError(
-                std::io::Error::from_raw_os_error(status),
-            )));
-        }
-        println!("return_length: {return_length}");
+    if status != STATUS_BUFFER_OVERFLOW
+        && status != STATUS_BUFFER_TOO_SMALL
+        && status != STATUS_INFO_LENGTH_MISMATCH
+    {
+        return Err(Error::WindowsApi(WindowsApiErrorType::WindowsOsError(
+            std::io::Error::from_raw_os_error(status),
+        )));
+    }
 
-        let buf_len = (return_length as usize) / 2;
-        let mut buffer: Vec<u16> = vec![0; buf_len + 1];
-        buffer.resize(buf_len + 1, 0); // set everything to 0
+    #[cfg(test)]
+    println!("return_length: {return_length}");
 
-        let status: NTSTATUS = NtQueryInformationProcess(
+    let buf_len = (return_length as usize) / 2;
+    let mut buffer: Vec<u16> = vec![0; buf_len + 1];
+    buffer.resize(buf_len + 1, 0); // set everything to 0
+
+    let status: NTSTATUS = unsafe {
+        NtQueryInformationProcess(
             handler,
             PROCESS_COMMAND_LINE_INFORMATION_CLASS,
             buffer.as_mut_ptr() as *mut _,
             return_length,
             &mut return_length as *mut _,
-        );
-        if status < 0 {
-            eprintln!("NtQueryInformationProcess failed with status: {status}");
-            return Err(Error::WindowsApi(WindowsApiErrorType::WindowsOsError(
-                std::io::Error::from_raw_os_error(status),
-            )));
-        }
-        buffer.set_len(buf_len);
-        buffer.push(0);
-
-        let cmd_buffer = *(buffer.as_ptr() as *const UNICODE_STRING);
-
-        let cmd = String::from_utf16_lossy(std::slice::from_raw_parts(
-            cmd_buffer.Buffer,
-            (cmd_buffer.Length / 2) as usize,
-        ));
-
-        Ok(cmd)
+        )
+    };
+    if status < 0 {
+        eprintln!("NtQueryInformationProcess failed with status: {status}");
+        return Err(Error::WindowsApi(WindowsApiErrorType::WindowsOsError(
+            std::io::Error::from_raw_os_error(status),
+        )));
     }
+    unsafe { buffer.set_len(buf_len) };
+    buffer.push(0);
+
+    let cmd_buffer = unsafe { *(buffer.as_ptr() as *const UNICODE_STRING) };
+
+    let cmd = String::from_utf16_lossy(unsafe {
+        std::slice::from_raw_parts(cmd_buffer.Buffer, (cmd_buffer.Length / 2) as usize)
+    });
+
+    Ok(cmd)
 }
 
 #[allow(dead_code)]
@@ -388,9 +368,6 @@ mod tests {
         let name = super::get_process_name(handler).unwrap();
         let full_name = super::get_process_full_name(handler).unwrap();
         let cmd = super::get_process_cmd(handler).unwrap();
-
-        let base_info = super::query_basic_process_info(handler);
-        assert!(base_info.is_ok(), "base_info must be ok");
 
         assert!(
             !name.as_os_str().is_empty(),

--- a/proxy_agent/src/proxy_agent_status.rs
+++ b/proxy_agent/src/proxy_agent_status.rs
@@ -282,7 +282,7 @@ impl ProxyAgentStatusTask {
 
     async fn write_aggregate_status_to_file(&self, status: GuestProxyAgentAggregateStatus) {
         let full_file_path = self.status_dir.join("status.json");
-        if let Err(e) = misc_helpers::json_write_to_file(&status, &full_file_path) {
+        if let Err(e) = misc_helpers::json_write_to_file_async(&status, &full_file_path).await {
             self.update_agent_status_message(format!(
                 "Error writing aggregate status to status file: {e}"
             ))

--- a/proxy_agent/src/proxy_agent_status.rs
+++ b/proxy_agent/src/proxy_agent_status.rs
@@ -155,7 +155,8 @@ impl ProxyAgentStatusTask {
                         message: status,
                         duration: status_report_time.elapsed().as_millis() as i64,
                     },
-                );
+                )
+                .await;
                 status_report_time = Instant::now();
             }
             // write the aggregate status to status.json file

--- a/proxy_agent/src/service.rs
+++ b/proxy_agent/src/service.rs
@@ -57,9 +57,8 @@ pub async fn start_service(shared_state: SharedState) {
 
     tokio::spawn({
         let key_keeper = KeyKeeper::new(
-            (format!("http://{}/", constants::WIRE_SERVER_IP))
-                .parse()
-                .unwrap(),
+            constants::WIRE_SERVER_IP.to_string(),
+            80,
             config::get_keys_dir(),
             proxy_agent_aggregate_status::get_proxy_agent_aggregate_status_folder(),
             config::get_poll_key_status_duration(),

--- a/proxy_agent/src/service.rs
+++ b/proxy_agent/src/service.rs
@@ -46,7 +46,7 @@ pub async fn start_service(shared_state: SharedState) {
 
     let start_message = format!(
         "============== GuestProxyAgent ({}) is starting on {}({}), elapsed: {}",
-        proxy_agent_shared::misc_helpers::get_current_version(),
+        current_info::get_current_exe_version(),
         current_info::get_long_os_version(),
         current_info::get_cpu_arch(),
         helpers::get_elapsed_time_in_millisec()

--- a/proxy_agent_extension/src/handler_main.rs
+++ b/proxy_agent_extension/src/handler_main.rs
@@ -41,7 +41,7 @@ pub async fn program_start(command: ExtensionCommand, config_seq_no: String) {
 
     logger::write(format!(
         "GuestProxyAgentExtension Version: {}, OS Arch: {}, OS Version: {}",
-        misc_helpers::get_current_version(),
+        current_info::get_current_exe_version(),
         misc_helpers::get_processor_arch(),
         misc_helpers::get_long_os_version()
     ));

--- a/proxy_agent_extension/src/handler_main.rs
+++ b/proxy_agent_extension/src/handler_main.rs
@@ -6,6 +6,7 @@ use crate::logger;
 use crate::structs;
 use crate::ExtensionCommand;
 use once_cell::sync::Lazy;
+use proxy_agent_shared::current_info;
 use proxy_agent_shared::misc_helpers;
 use proxy_agent_shared::version::Version;
 use std::fs::{self};

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -28,7 +28,7 @@ const MAX_STATE_COUNT: u32 = 120;
 pub fn run() {
     let message = format!(
         "==============  GuestProxyAgentExtension Enabling Agent, Version: {}, OS Arch: {}, OS Version: {}",
-        misc_helpers::get_current_version(),
+        current_info::get_current_exe_version(),
         misc_helpers::get_processor_arch(),
         misc_helpers::get_long_os_version()
     );

--- a/proxy_agent_extension/src/service_main.rs
+++ b/proxy_agent_extension/src/service_main.rs
@@ -4,6 +4,7 @@ use crate::common;
 use crate::constants;
 use crate::logger;
 use crate::structs::*;
+use proxy_agent_shared::current_info;
 use proxy_agent_shared::logger::LoggerLevel;
 use proxy_agent_shared::proxy_agent_aggregate_status::{
     self, GuestProxyAgentAggregateStatus, ProxyConnectionSummary,

--- a/proxy_agent_setup/src/main.rs
+++ b/proxy_agent_setup/src/main.rs
@@ -32,7 +32,7 @@ async fn main() {
     let cli = args::Cli::parse();
     logger::write(format!(
         "\r\n\r\n============== ProxyAgent Setup Tool ({}) is starting with args: {} ==============",
-        misc_helpers::get_current_version(),
+        current_info::get_current_exe_version(),
         cli
     ));
 

--- a/proxy_agent_setup/src/main.rs
+++ b/proxy_agent_setup/src/main.rs
@@ -13,6 +13,7 @@ pub mod setup;
 mod linux;
 
 use clap::Parser;
+use proxy_agent_shared::current_info;
 use proxy_agent_shared::misc_helpers;
 use proxy_agent_shared::service;
 use std::process;

--- a/proxy_agent_setup/src/running.rs
+++ b/proxy_agent_setup/src/running.rs
@@ -26,8 +26,7 @@ pub fn proxy_agent_running_folder(_service_name: &str) -> PathBuf {
 pub fn proxy_agent_parent_folder() -> PathBuf {
     #[cfg(windows)]
     {
-        let path = misc_helpers::resolve_env_variables("%SYSTEMDRIVE%\\WindowsAzure\\ProxyAgent")
-            .unwrap_or("C:\\WindowsAzure\\ProxyAgent".to_string());
+        let path = misc_helpers::resolve_env_variables("%SYSTEMDRIVE%\\WindowsAzure\\ProxyAgent");
         PathBuf::from(path)
     }
     #[cfg(not(windows))]

--- a/proxy_agent_shared/Cargo.toml
+++ b/proxy_agent_shared/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1.0.91"         # json Deserializer
 serde-xml-rs = "0.8.1"        # xml Deserializer with xml attribute
 regex = "1.11"               # match file name 
 thiserror = "1.0.64"
-tokio = { version = "1", features = ["rt", "macros", "net", "sync", "time"] }
+tokio = { version = "1", features = ["rt", "macros", "net", "sync", "time", "fs"] }
 tokio-util = "0.7.11"
 libc = "0.2.147"
 log = { version = "0.4.26", features = ["std"] }

--- a/proxy_agent_shared/src/etw/etw_writter.rs
+++ b/proxy_agent_shared/src/etw/etw_writter.rs
@@ -45,7 +45,7 @@ impl WindowsEventWritter {
         );
         let value = crate::misc_helpers::resolve_env_variables(
             r"%SystemRoot%\Microsoft.NET\Framework64\v4.0.30319\EventLogMessages.dll",
-        )?;
+        );
         crate::windows::set_reg_string(&key_name, "EventMessageFile", value)?;
 
         let source_name_wide = super::to_wide(source_name);

--- a/proxy_agent_shared/src/host_clients/wire_server_client.rs
+++ b/proxy_agent_shared/src/host_clients/wire_server_client.rs
@@ -4,14 +4,13 @@
 //! This module contains the logic to interact with the wire server for sending telemetry data and getting goal state.
 
 use crate::host_clients::goal_state::{GoalState, SharedConfig};
-use crate::hyper_client;
+use crate::hyper_client::{self, HostEndpoint};
 use crate::{
     error::{Error, WireServerErrorType},
     logger::logger_manager,
     result::Result,
 };
 use http::Method;
-use hyper::Uri;
 use std::collections::HashMap;
 
 pub struct WireServerClient {
@@ -19,8 +18,8 @@ pub struct WireServerClient {
     port: u16,
 }
 
-const TELEMETRY_DATA_URI: &str = "machine/?comp=telemetrydata";
-const GOALSTATE_URI: &str = "machine?comp=goalstate";
+const TELEMETRY_DATA_URI: &str = "/machine/?comp=telemetrydata";
+const GOALSTATE_URI: &str = "/machine?comp=goalstate";
 
 impl WireServerClient {
     pub fn new(ip: &str, port: u16) -> Self {
@@ -30,15 +29,16 @@ impl WireServerClient {
         }
     }
 
+    fn endpoint(&self, path: &str) -> HostEndpoint {
+        HostEndpoint::new(&self.ip, self.port, path)
+    }
+
     pub async fn send_telemetry_data(&self, xml_data: String) -> Result<()> {
         if xml_data.is_empty() {
             return Ok(());
         }
 
-        let url = format!("http://{}:{}/{}", self.ip, self.port, TELEMETRY_DATA_URI);
-        let url: Uri = url
-            .parse::<hyper::Uri>()
-            .map_err(|e| Error::ParseUrl(url, e.to_string()))?;
+        let endpoint = self.endpoint(TELEMETRY_DATA_URI);
         let mut headers = HashMap::new();
         headers.insert("x-ms-version".to_string(), "2012-11-30".to_string());
         headers.insert(
@@ -48,7 +48,7 @@ impl WireServerClient {
 
         let request = hyper_client::build_request(
             Method::POST,
-            &url,
+            &endpoint,
             &headers,
             Some(xml_data.as_bytes()),
             None, // post telemetry data does not require signing
@@ -75,7 +75,7 @@ impl WireServerClient {
         if !status.is_success() {
             return Err(Error::WireServer(
                 WireServerErrorType::Telemetry,
-                format!("Failed to get response from {url}, status code: {status}"),
+                format!("Failed to get response from {endpoint}, status code: {status}",),
             ));
         }
 
@@ -87,16 +87,19 @@ impl WireServerClient {
         key_guid: Option<String>,
         key: Option<String>,
     ) -> Result<GoalState> {
-        let url = format!("http://{}:{}/{}", self.ip, self.port, GOALSTATE_URI);
-        let url = url
-            .parse::<hyper::Uri>()
-            .map_err(|e| Error::ParseUrl(url, e.to_string()))?;
+        let endpoint = self.endpoint(GOALSTATE_URI);
         let mut headers = HashMap::new();
         headers.insert("x-ms-version".to_string(), "2012-11-30".to_string());
 
-        hyper_client::get(&url, &headers, key_guid, key, logger_manager::write_warn)
-            .await
-            .map_err(|e| Error::WireServer(WireServerErrorType::GoalState, e.to_string()))
+        hyper_client::get(
+            &endpoint,
+            &headers,
+            key_guid,
+            key,
+            logger_manager::write_warn,
+        )
+        .await
+        .map_err(|e| Error::WireServer(WireServerErrorType::GoalState, e.to_string()))
     }
 
     pub async fn get_shared_config(
@@ -106,13 +109,21 @@ impl WireServerClient {
         key: Option<String>,
     ) -> Result<SharedConfig> {
         let mut headers = HashMap::new();
-        let url = url
-            .parse::<hyper::Uri>()
-            .map_err(|e| Error::ParseUrl(url, e.to_string()))?;
         headers.insert("x-ms-version".to_string(), "2012-11-30".to_string());
 
-        hyper_client::get(&url, &headers, key_guid, key, logger_manager::write_warn)
-            .await
-            .map_err(|e| Error::WireServer(WireServerErrorType::SharedConfig, e.to_string()))
+        let uri = url
+            .parse::<hyper::Uri>()
+            .map_err(|e| Error::ParseUrl(url.clone(), e.to_string()))?;
+        let endpoint = HostEndpoint::from_full_uri(uri)?;
+
+        hyper_client::get(
+            &endpoint,
+            &headers,
+            key_guid,
+            key,
+            logger_manager::write_warn,
+        )
+        .await
+        .map_err(|e| Error::WireServer(WireServerErrorType::SharedConfig, e.to_string()))
     }
 }

--- a/proxy_agent_shared/src/hyper_client.rs
+++ b/proxy_agent_shared/src/hyper_client.rs
@@ -471,6 +471,7 @@ mod tests {
     use crate::{
         host_clients::{imds_client::ImdsClient, wire_server_client::WireServerClient},
         logger::logger_manager,
+        server_mock,
     };
     use tokio_util::sync::CancellationToken;
 
@@ -510,13 +511,11 @@ mod tests {
     async fn http_request_tests() {
         // start mock server
         let ip = "127.0.0.1";
-        let port = 7072u16;
+        let port = 9072u16;
         let cancellation_token = CancellationToken::new();
-        tokio::spawn(crate::server_mock::start(
-            ip.to_string(),
-            port,
-            cancellation_token.clone(),
-        ));
+        let port = server_mock::start(ip.to_string(), port, cancellation_token.clone())
+            .await
+            .unwrap();
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         logger_manager::write_info("server_mock started.".to_string());
 

--- a/proxy_agent_shared/src/hyper_client.rs
+++ b/proxy_agent_shared/src/hyper_client.rs
@@ -31,8 +31,91 @@ pub const CLAIMS_IS_ROOT: &str = "isRoot";
 
 const LF: &str = "\n";
 
+/// Pre-parsed HTTP endpoint containing host, port, and path/query.
+/// Use this to avoid re-parsing URIs multiple times which is performance-sensitive.
+#[derive(Debug, Clone)]
+pub struct HostEndpoint {
+    pub host: String,
+    pub port: u16,
+    /// The path and query portion of the URI (e.g., "/api/status?version=1")
+    pub path_and_query: String,
+}
+
+impl HostEndpoint {
+    /// Create a new HostEndpoint with explicit components
+    pub fn new(host: impl Into<String>, port: u16, path_and_query: impl Into<String>) -> Self {
+        Self {
+            host: host.into(),
+            port,
+            path_and_query: path_and_query.into(),
+        }
+    }
+
+    /// Create a HostEndpoint from a full URI string (e.g., "http://host:port/path?query")
+    /// This will parse the URI and extract the host, port, and path/query components.
+    /// Remark: Do not use this function in performance-sensitive code paths, as URI parsing can be relatively expensive.
+    ///     Instead, use the `new` constructor with pre-parsed components when possible.
+    /// Remark: This function assumes the URI is well-formed and contains a host. It will return an error if the URI is invalid or missing required components.
+    pub fn from_full_uri(uri: Uri) -> Result<Self> {
+        let host = match uri.host() {
+            Some(h) => h.to_string(),
+            None => {
+                return Err(Error::Hyper(HyperErrorType::RequestBuilder(
+                    "URI must have a host".to_string(),
+                )));
+            }
+        };
+        let default_port = if uri.scheme_str() == Some("https") {
+            443
+        } else {
+            80
+        };
+        let port = uri.port_u16().unwrap_or(default_port);
+        let path_and_query = match uri.path_and_query() {
+            Some(pq) => pq.as_str().to_string(),
+            None => "/".to_string(), // default to root path
+        };
+
+        Ok(Self {
+            host,
+            port,
+            path_and_query,
+        })
+    }
+
+    /// Create a HostEndpoint from a URI string (e.g., "http://host:port/path?query")
+    /// This will parse the URI and extract the host, port, and path/query components.
+    /// Remark: Do not use this function in performance-sensitive code paths, as URI parsing can be relatively expensive.
+    ///     Instead, use the `new` constructor with pre-parsed components when possible.
+    pub fn from_uri_str(uri_str: &str) -> Result<Self> {
+        let uri = uri_str.parse::<Uri>().map_err(|e| {
+            Error::Hyper(HyperErrorType::RequestBuilder(format!(
+                "Failed to parse URI string: {uri_str} with error: {e}"
+            )))
+        })?;
+        Self::from_full_uri(uri)
+    }
+
+    /// Get the address string for TCP connection (host:port)
+    #[inline]
+    pub fn addr(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+}
+
+impl std::fmt::Display for HostEndpoint {
+    /// Format as full URI string (e.g., "http://host:port/path?query")
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "http://{}:{}{}",
+            self.host, self.port, self.path_and_query
+        )
+    }
+}
+
 pub async fn get<T, F>(
-    full_url: &Uri,
+    endpoint: &HostEndpoint,
     headers: &HashMap<String, String>,
     key_guid: Option<String>,
     key: Option<String>,
@@ -42,14 +125,13 @@ where
     T: DeserializeOwned,
     F: Fn(String) + Send + 'static,
 {
-    let request = build_request(Method::GET, full_url, headers, None, key_guid, key)?;
+    let request = build_request(Method::GET, endpoint, headers, None, key_guid, key)?;
 
-    let (host, port) = host_port_from_uri(full_url)?;
-    let response = send_request(&host, port, request, log_fun).await?;
+    let response = send_request(&endpoint.host, endpoint.port, request, log_fun).await?;
     let status = response.status();
     if !status.is_success() {
         return Err(Error::Hyper(HyperErrorType::ServerError(
-            full_url.to_string(),
+            endpoint.to_string(),
             status,
         )));
     }
@@ -162,22 +244,20 @@ where
 
 pub fn build_request(
     method: http::Method,
-    full_url: &Uri,
+    endpoint: &HostEndpoint,
     headers: &HashMap<String, String>,
     body: Option<&[u8]>,
     key_guid: Option<String>,
     key: Option<String>,
 ) -> Result<Request<BoxBody<Bytes, hyper::Error>>> {
-    let (host, _) = host_port_from_uri(full_url)?;
-
     let mut request_builder = Request::builder()
         .method(method)
-        .uri(match full_url.path_and_query() {
-            Some(pq) => pq.as_str(),
-            None => full_url.path(),
-        })
+        .uri(&endpoint.path_and_query)
         .header(DATE_HEADER, misc_helpers::get_date_time_rfc1123_string())
-        .header(hyper::header::HOST, host)
+        // The header() method accepts types that implement Into<HeaderValue>, and &str implements this trait.
+        // The HeaderValue will internally copy the bytes (which is unavoidable since it needs to own the data),
+        // So you're not creating any intermediate String allocations.
+        .header(hyper::header::HOST, &endpoint.host)
         .header(
             CLAIMS_HEADER,
             format!("{{ \"{}\": \"{}\"}}", CLAIMS_IS_ROOT, true,),
@@ -276,21 +356,6 @@ where
     });
 
     Ok(sender)
-}
-
-pub fn host_port_from_uri(full_url: &Uri) -> Result<(String, u16)> {
-    let host = match full_url.host() {
-        Some(h) => h.to_string(),
-        None => {
-            return Err(Error::ParseUrl(
-                full_url.to_string(),
-                "Failed to get host from uri".to_string(),
-            ))
-        }
-    };
-    let port = full_url.port_u16().unwrap_or(80);
-
-    Ok((host, port))
 }
 
 /*

--- a/proxy_agent_shared/src/misc_helpers.rs
+++ b/proxy_agent_shared/src/misc_helpers.rs
@@ -25,32 +25,47 @@ pub fn get_thread_identity() -> String {
     format!("{:0>8}", thread_id::get())
 }
 
-pub fn get_date_time_string_with_milliseconds() -> String {
-    let date_format =
-        format_description::parse("[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond]")
-            .unwrap();
+// Static format descriptors parsed once and reused for all calls
+static ISO8601_MILLIS_FORMAT: std::sync::LazyLock<
+    Vec<time::format_description::FormatItem<'static>>,
+> = std::sync::LazyLock::new(|| {
+    format_description::parse("[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond]")
+        .expect("Invalid ISO8601 millis date format")
+});
 
-    let time_str = OffsetDateTime::now_utc().format(&date_format).unwrap();
+static ISO8601_FORMAT: std::sync::LazyLock<Vec<time::format_description::FormatItem<'static>>> =
+    std::sync::LazyLock::new(|| {
+        format_description::parse("[year]-[month]-[day]T[hour]:[minute]:[second]Z")
+            .expect("Invalid ISO8601 date format")
+    });
+
+// This format is also the preferred HTTP date format. https://httpwg.org/specs/rfc9110.html#http.date
+static RFC1123_FORMAT: std::sync::LazyLock<Vec<time::format_description::FormatItem<'static>>> =
+    std::sync::LazyLock::new(|| {
+        format_description::parse(
+            "[weekday repr:short], [day] [month repr:short] [year] [hour]:[minute]:[second] GMT",
+        )
+        .expect("Invalid RFC1123 date format")
+    });
+
+pub fn get_date_time_string_with_milliseconds() -> String {
+    let time_str = OffsetDateTime::now_utc()
+        .format(&*ISO8601_MILLIS_FORMAT)
+        .expect("Failed to format ISO8601 millis date");
+    // Truncate to 23 chars: "YYYY-MM-DDTHH:MM:SS.mmm"
     time_str.chars().take(23).collect()
 }
 
 pub fn get_date_time_string() -> String {
-    let date_format =
-        format_description::parse("[year]-[month]-[day]T[hour]:[minute]:[second]Z").unwrap();
-
-    let time_str = OffsetDateTime::now_utc().format(&date_format).unwrap();
-    time_str.chars().collect()
+    OffsetDateTime::now_utc()
+        .format(&*ISO8601_FORMAT)
+        .expect("Failed to format ISO8601 date")
 }
 
-// This format is also the preferred HTTP date format. https://httpwg.org/specs/rfc9110.html#http.date
 pub fn get_date_time_rfc1123_string() -> String {
-    let date_format = format_description::parse(
-        "[weekday repr:short], [day] [month repr:short] [year] [hour]:[minute]:[second] GMT",
-    )
-    .unwrap();
-
-    let time_str = OffsetDateTime::now_utc().format(&date_format).unwrap();
-    time_str.chars().collect()
+    OffsetDateTime::now_utc()
+        .format(&*RFC1123_FORMAT)
+        .expect("Failed to format RFC1123 date")
 }
 
 pub fn get_date_time_unix_nano() -> i128 {
@@ -126,15 +141,41 @@ pub fn try_create_folder(dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Writes a serializable object to a file in JSON format.
+/// It first writes to a temporary file and then renames it to the target file to avoid leaving a corrupted file if the write operation fails.
+/// Remark: it uses BufWriter to reduce system calls and improve performance.
+/// Remark: Called from sync code, infrequent writes and small objects
 pub fn json_write_to_file<T>(obj: &T, file_path: &Path) -> Result<()>
 where
     T: ?Sized + Serialize,
 {
+    use std::io::BufWriter;
+
     // write to a temp file and rename to avoid corrupted file
     let temp_file_path = file_path.with_extension("tmp");
     let file = File::create(&temp_file_path)?;
-    serde_json::to_writer_pretty(file, obj)?;
+    let writer = BufWriter::new(file); // Reduces system calls
+    serde_json::to_writer_pretty(writer, obj)?;
     std::fs::rename(temp_file_path, file_path)?;
+
+    Ok(())
+}
+
+/// Async version of json_write_to_file using tokio::fs
+/// Serializes to memory first (CPU work), then writes asynchronously (IO work)
+/// This avoids blocking the async runtime during serialization
+/// Remark: Called from async context, writing while handing concurrent requests, and potentially larger objects
+pub async fn json_write_to_file_async<T>(obj: &T, file_path: &Path) -> Result<()>
+where
+    T: ?Sized + Serialize,
+{
+    // Serialize to memory first (CPU work - fast)
+    let json_bytes = serde_json::to_vec_pretty(obj)?;
+
+    // Write asynchronously (IO work)
+    let temp_file_path = file_path.with_extension("tmp");
+    tokio::fs::write(&temp_file_path, json_bytes).await?;
+    tokio::fs::rename(&temp_file_path, file_path).await?;
 
     Ok(())
 }
@@ -378,21 +419,31 @@ pub fn get_proxy_agent_version(proxy_agent_exe: &Path) -> Result<String> {
     }
 }
 
+/// Static regex for matching environment variables like %VAR%
+/// expect() only panics on failure to compile the regex, which should not happen since the pattern is constant and valid
+/// This is the idiomatic Rust pattern for creating a static regex that is compiled once and reused, ensuring thread safety and performance
+/// Remark: Regex::new is performance-sensitive, so we use LazyLock to compile it only once and reuse it for subsequent calls to resolve_env_variables, which can be called frequently.
+///     This avoids the overhead of compiling the regex on every call, improving performance while ensuring thread safety.
+static ENV_VAR_REGEX: std::sync::LazyLock<Regex> =
+    std::sync::LazyLock::new(|| Regex::new(r"%(\w+)%").expect("Invalid env var regex pattern"));
+
 /// This function replaces all occurrences of %VAR% in the input string with the value of the environment variable VAR
 /// If the environment variable is not set, it returns the original string with VAR unchanged.
 /// # Arguments
 /// * `input` - The input string to resolve environment variables in
 /// # Returns
-/// A Result containing the resolved string or an error if the regex pattern is invalid
-pub fn resolve_env_variables(input: &str) -> Result<String> {
-    let re = Regex::new(r"%(\w+)%")?;
-    let ret = re
+/// The resolved string with environment variables expanded
+pub fn resolve_env_variables(input: &str) -> String {
+    if input.is_empty() || !input.contains('%') {
+        // If the input string is empty or does not contain '%', return the original string
+        return input.to_string();
+    }
+
+    ENV_VAR_REGEX
         .replace_all(input, |caps: &regex::Captures| {
             std::env::var(&caps[1]).unwrap_or_else(|_| caps[1].to_string())
         })
-        .to_string();
-
-    Ok(ret)
+        .to_string()
 }
 
 /// Compute HMAC-SHA256 signature for the input using the provided hex-encoded key
@@ -647,12 +698,12 @@ mod tests {
             "{}\\WindowsAzure\\ProxyAgent\\Package_1.0.0",
             env::var("SYSTEMDRIVE").unwrap_or("SYSTEMDRIVE".to_string())
         );
-        let resolved = super::resolve_env_variables(input).unwrap();
+        let resolved = super::resolve_env_variables(input);
         assert_eq!(expected, resolved, "resolved string mismatch");
 
         let input = "/var/log/azure-proxy-agent/";
         let expected = "/var/log/azure-proxy-agent/".to_string();
-        let resolved = super::resolve_env_variables(input).unwrap();
+        let resolved = super::resolve_env_variables(input);
         assert_eq!(expected, resolved, "resolved string mismatch");
     }
 

--- a/proxy_agent_shared/src/proxy_agent_aggregate_status.rs
+++ b/proxy_agent_shared/src/proxy_agent_aggregate_status.rs
@@ -12,8 +12,7 @@ const PROXY_AGENT_AGGREGATE_STATUS_FOLDER: &str = "/var/log/azure-proxy-agent/";
 pub const PROXY_AGENT_AGGREGATE_STATUS_FILE_NAME: &str = "status.json";
 
 pub fn get_proxy_agent_aggregate_status_folder() -> std::path::PathBuf {
-    let path = misc_helpers::resolve_env_variables(PROXY_AGENT_AGGREGATE_STATUS_FOLDER)
-        .unwrap_or(PROXY_AGENT_AGGREGATE_STATUS_FOLDER.to_string());
+    let path = misc_helpers::resolve_env_variables(PROXY_AGENT_AGGREGATE_STATUS_FOLDER);
     PathBuf::from(path)
 }
 

--- a/proxy_agent_shared/src/secrets_redactor.rs
+++ b/proxy_agent_shared/src/secrets_redactor.rs
@@ -1,7 +1,33 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
+use std::borrow::Cow;
+
 const REDACTED_TEXT: &str = "[REDACTED]";
+
+/// Common substrings that indicate a secret might be present - for quick pre-filtering
+/// These are not regex patterns, just simple substrings to check for before running the more expensive regexes.
+const SECRET_INDICATORS: [&str; 15] = [
+    "pwd=",
+    "password=",
+    "AccountKey=",
+    "PrimaryKey=",
+    "SecondaryKey=",
+    "sig=",
+    "AzCa",
+    "PRIVATE KEY",
+    "token",
+    "ado",
+    "vsts",
+    "key",
+    "secret",
+    "authorization",
+    "eyJ",
+];
+
+/// Regular expression patterns to identify secrets. These are more expensive to run, so we first check for indicators.
+/// Remarks: when add more patterns, please also add corresponding indicators in SECRET_INDICATORS for better performance.
+///     And try to make the pattern as specific as possible to avoid false positives and unnecessary redaction.
 const CRED_PATTERNS: [&str; 17] = [
             // SQL Connection String Password
             "pwd=[^;]*", 
@@ -45,18 +71,44 @@ fn init_regex_patterns() -> Vec<regex::Regex> {
     patterns
 }
 
-pub fn redact_secrets(text: String) -> String {
-    if text.is_empty() {
-        return text;
+/// Quick check if text might contain secrets (case-insensitive for most indicators)
+#[inline]
+fn might_contain_secrets(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    SECRET_INDICATORS.iter().any(|indicator| {
+        if *indicator == "AzCa" || *indicator == "PRIVATE KEY" || *indicator == "eyJ" {
+            // Case-sensitive check for these
+            text.contains(indicator)
+        } else {
+            lower.contains(&indicator.to_ascii_lowercase())
+        }
+    })
+}
+
+/// Redacts secrets from text. Returns the original text unchanged if no secrets found.
+/// Takes `&str` to avoid unnecessary ownership transfer.
+fn redact_secrets(text: &str) -> Cow<'_, str> {
+    if text.is_empty() || !might_contain_secrets(text) {
+        return Cow::Borrowed(text);
     }
 
-    let mut redacted_text = text.clone();
+    let mut redacted_text = Cow::Borrowed(text);
     for pattern in REGEX_PATTERNS.iter() {
-        redacted_text = pattern
-            .replace_all(&redacted_text, REDACTED_TEXT)
-            .to_string();
+        if let Cow::Owned(s) = pattern.replace_all(&redacted_text, REDACTED_TEXT) {
+            redacted_text = Cow::Owned(s);
+        }
     }
     redacted_text
+}
+
+/// Convenience function that takes ownership and returns String
+/// Use this when you already have a String and need a String back
+#[inline]
+pub fn redact_secrets_string(text: String) -> String {
+    match redact_secrets(&text) {
+        Cow::Borrowed(_) => text, // No changes, return original
+        Cow::Owned(s) => s,       // Changed, return new string
+    }
 }
 
 #[cfg(test)]
@@ -121,7 +173,23 @@ authorization: aws4-hmac-sha256"#,
             ),
         ];
         for (input, expected) in test_strings {
-            assert_eq!(redact_secrets(input.to_string()), expected.to_string());
+            assert_eq!(redact_secrets(input), expected);
         }
+    }
+
+    #[test]
+    fn test_no_secrets_no_allocation() {
+        let text = "This is a normal log message without any secrets";
+        let result = redact_secrets(text);
+        // Should return Borrowed (no allocation) when no secrets found
+        assert!(matches!(result, std::borrow::Cow::Borrowed(_)));
+        assert_eq!(result, text);
+    }
+
+    #[test]
+    fn test_redact_secrets_string() {
+        let text = "pwd=secret123;".to_string();
+        let result = redact_secrets_string(text);
+        assert_eq!(result, "[REDACTED];");
     }
 }

--- a/proxy_agent_shared/src/server_mock.rs
+++ b/proxy_agent_shared/src/server_mock.rs
@@ -21,38 +21,59 @@ static EMPTY_GUID: Lazy<String> = Lazy::new(|| "00000000-0000-0000-0000-00000000
 static GUID: Lazy<String> = Lazy::new(|| Uuid::new_v4().to_string());
 static mut CURRENT_STATE: Lazy<String> = Lazy::new(|| String::from("wireserver"));
 
-pub async fn start(ip: String, port: u16, cancellation_token: CancellationToken) {
+/// A mock server to simulate the behavior of the Azure WireServer for testing purposes.
+/// It listens for incoming HTTP requests and responds with predefined responses based on the request path and method.
+/// The server can be started on a specified IP and port, and it can be gracefully shut down using a cancellation token.
+/// If the port is already in use, it will automatically bind to an ephemeral port and log a warning message.
+/// Returns the port number that the server is listening on, or an error if the server fails to start.
+pub async fn start(ip: String, port: u16, cancellation_token: CancellationToken) -> Result<u16> {
     logger_manager::write_info("Mock Server starting...".to_string());
     let addr = format!("{ip}:{port}");
-    let listener = TcpListener::bind(&addr).await.unwrap();
-    println!("Listening on http://{addr}");
-
-    loop {
-        tokio::select! {
-            _ = cancellation_token.cancelled() => {
-                logger_manager::write_warn("cancellation token signal received, stop the listener.".to_string());
-                return;
+    let listener = match TcpListener::bind(&addr).await {
+        Ok(l) => l,
+        Err(e) => {
+            // if the specified port is already in use, bind to an ephemeral port instead
+            if e.kind() == std::io::ErrorKind::AddrInUse {
+                logger_manager::write_warn(format!(
+                    "Port {port} is already in use, trying to bind to an ephemeral port."
+                ));
+                TcpListener::bind(format!("{ip}:0")).await?
+            } else {
+                return Err(e.into());
             }
-            result = listener.accept() => {
-                match result {
-                    Ok((stream, _)) =>{
-                        let ip = ip.to_string();
-                        tokio::spawn(async move {
-                            let io = TokioIo::new(stream);
+        }
+    };
+    let local_addr = listener.local_addr().unwrap();
+    println!("Mock Server Listening on http://{local_addr}");
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = cancellation_token.cancelled() => {
+                    logger_manager::write_warn("cancellation token signal received, stop the listener.".to_string());
+                    return;
+                }
+                result = listener.accept() => {
+                    match result {
+                        Ok((stream, _)) =>{
                             let ip = ip.to_string();
-                            let service = service_fn(move |req| handle_request(ip.to_string(), port, req));
-                            if let Err(err) = http1::Builder::new().serve_connection(io, service).await {
-                                println!("Error serving connection: {err:?}");
-                            }
-                        });
-                    },
-                    Err(e) => {
-                        logger_manager::write_err(format!("Failed to accept connection: {e}"));
+                            tokio::spawn(async move {
+                                let io = TokioIo::new(stream);
+                                let ip = ip.to_string();
+                                let service = service_fn(move |req| handle_request(ip.to_string(), port, req));
+                                if let Err(err) = http1::Builder::new().serve_connection(io, service).await {
+                                    println!("Error serving connection: {err:?}");
+                                }
+                            });
+                        },
+                        Err(e) => {
+                            logger_manager::write_err(format!("Failed to accept connection: {e}"));
+                        }
                     }
                 }
             }
         }
-    }
+    });
+    Ok(local_addr.port())
 }
 
 async fn handle_request(

--- a/proxy_agent_shared/src/server_mock.rs
+++ b/proxy_agent_shared/src/server_mock.rs
@@ -44,6 +44,8 @@ pub async fn start(ip: String, port: u16, cancellation_token: CancellationToken)
         }
     };
     let local_addr = listener.local_addr().unwrap();
+    // Update the port if we had to bind to an ephemeral port
+    let port = local_addr.port();
     println!("Mock Server Listening on http://{local_addr}");
     tokio::spawn(async move {
         loop {
@@ -73,7 +75,7 @@ pub async fn start(ip: String, port: u16, cancellation_token: CancellationToken)
             }
         }
     });
-    Ok(local_addr.port())
+    Ok(port)
 }
 
 async fn handle_request(

--- a/proxy_agent_shared/src/telemetry.rs
+++ b/proxy_agent_shared/src/telemetry.rs
@@ -13,6 +13,10 @@ pub const GENERIC_EVENT_FILE_SEARCH_PATTERN: &str = r"^[0-9]+\.json$";
 pub fn new_generic_event_file_name() -> String {
     format!("{}.json", misc_helpers::get_date_time_unix_nano())
 }
+pub const EXTENSION_EVENT_FILE_SEARCH_PATTERN: &str = r"^extension_[0-9]+\.json$";
+pub fn new_extension_event_file_name() -> String {
+    format!("extension_{}.json", misc_helpers::get_date_time_unix_nano())
+}
 
 /// Represents a telemetry event for TelemetryGenericLogsEvent
 #[derive(Serialize, Deserialize)]
@@ -43,6 +47,53 @@ impl Event {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Extension {
+    pub name: String,
+    pub version: String,
+    pub is_internal: bool,
+    pub extension_type: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct OperationStatus {
+    pub operation_success: bool,
+    pub operation: String,
+    pub task_name: String,
+    pub message: String,
+    pub duration: i64,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ExtensionStatusEvent {
+    pub extension: Extension,
+    pub operation_status: OperationStatus,
+
+    pub event_pid: String,
+    pub event_tid: String,
+    pub time_stamp: String,
+}
+
+impl ExtensionStatusEvent {
+    /// Create a new ExtensionStatusEvent
+    /// Rust does not recommend using too many arguments in a function,
+    /// so we use structs to group related arguments together.
+    /// # Arguments
+    /// * `extension` - The extension information
+    /// * `operation_status` - The operation status information
+    /// # Returns
+    /// A new instance of `ExtensionStatusEvent`
+    pub fn new(extension: Extension, operation_status: OperationStatus) -> Self {
+        ExtensionStatusEvent {
+            extension,
+            operation_status,
+            event_pid: std::process::id().to_string(),
+            event_tid: misc_helpers::get_thread_identity(),
+            time_stamp: misc_helpers::get_date_time_string_with_milliseconds(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
@@ -57,5 +108,34 @@ mod tests {
         assert_eq!(event.Message, "test message".to_string());
         assert_eq!(event.TaskName, "test task name".to_string());
         assert_eq!(event.OperationId, "test operation id".to_string());
+    }
+
+    #[test]
+    fn test_extension_status_event_new() {
+        let extension = super::Extension {
+            name: "test extension".to_string(),
+            version: "1.0.0".to_string(),
+            is_internal: true,
+            extension_type: "test type".to_string(),
+        };
+        let operation_status = super::OperationStatus {
+            operation_success: true,
+            task_name: "test task".to_string(),
+            operation: "test operation".to_string(),
+            message: "test message".to_string(),
+            duration: 100,
+        };
+        let event = super::ExtensionStatusEvent::new(extension.clone(), operation_status.clone());
+        assert_eq!(event.extension.name, extension.name);
+        assert_eq!(event.extension.version, extension.version);
+        assert_eq!(event.extension.is_internal, extension.is_internal);
+        assert_eq!(event.extension.extension_type, extension.extension_type);
+        assert_eq!(
+            event.operation_status.operation_success,
+            operation_status.operation_success
+        );
+        assert_eq!(event.operation_status.operation, operation_status.operation);
+        assert_eq!(event.operation_status.message, operation_status.message);
+        assert_eq!(event.operation_status.duration, operation_status.duration);
     }
 }

--- a/proxy_agent_shared/src/telemetry/event_logger.rs
+++ b/proxy_agent_shared/src/telemetry/event_logger.rs
@@ -102,7 +102,7 @@ pub async fn start<F, Fut>(
 
         let mut file_path = event_dir.to_path_buf();
         file_path.push(crate::telemetry::new_generic_event_file_name());
-        match misc_helpers::json_write_to_file(&events, &file_path) {
+        match misc_helpers::json_write_to_file_async(&events, &file_path).await {
             Ok(()) => {
                 logger_manager::write_log(
                     Level::Trace,
@@ -169,7 +169,7 @@ pub fn write_event_only(level: Level, message: String, method_name: &str, module
     };
 }
 
-pub fn report_extension_status_event(
+pub async fn report_extension_status_event(
     extension: crate::telemetry::Extension,
     operation_status: crate::telemetry::OperationStatus,
 ) {
@@ -210,7 +210,7 @@ pub fn report_extension_status_event(
     let event = crate::telemetry::ExtensionStatusEvent::new(extension, operation_status);
     let mut file_path = event_dir.to_path_buf();
     file_path.push(crate::telemetry::new_extension_event_file_name());
-    if let Err(e) = misc_helpers::json_write_to_file(&event, &file_path) {
+    if let Err(e) = misc_helpers::json_write_to_file_async(&event, &file_path).await {
         logger_manager::write_log(
             Level::Warn,
             format!(
@@ -261,7 +261,7 @@ mod tests {
         };
 
         // This should not panic even if EVENTS_DIR is not set
-        super::report_extension_status_event(extension, operation_status);
+        super::report_extension_status_event(extension, operation_status).await;
 
         // Start the event logger loop and set the EVENTS_DIR
         let cloned_events_dir = events_dir.to_path_buf();
@@ -326,7 +326,7 @@ mod tests {
         };
 
         // Call report_extension_status_event
-        super::report_extension_status_event(extension.clone(), operation_status.clone());
+        super::report_extension_status_event(extension.clone(), operation_status.clone()).await;
 
         // Wait for the file to be written
         tokio::time::sleep(Duration::from_millis(100)).await;

--- a/proxy_agent_shared/src/telemetry/event_reader.rs
+++ b/proxy_agent_shared/src/telemetry/event_reader.rs
@@ -450,4 +450,321 @@ mod tests {
         common_state.cancel_cancellation_token();
         _ = fs::remove_dir_all(&temp_dir);
     }
+
+    #[tokio::test]
+    async fn test_extension_status_event_processor() {
+        let mut temp_dir = env::temp_dir();
+        temp_dir.push("test_extension_status_event_processor");
+
+        _ = fs::remove_dir_all(&temp_dir);
+        let mut events_dir = temp_dir.to_path_buf();
+        events_dir.push("Events");
+        misc_helpers::try_create_folder(&events_dir).unwrap();
+
+        let cancellation_token = CancellationToken::new();
+        let common_state = CommonState::start_new(cancellation_token.clone());
+        let event_reader = EventReader::new(
+            events_dir.clone(),
+            common_state.clone(),
+            "Test".to_string(),
+            "test_extension_status_event_processor".to_string(),
+        );
+
+        // Create test extension status event files
+        let extension = crate::telemetry::Extension {
+            name: "test_extension".to_string(),
+            version: "1.0.0".to_string(),
+            is_internal: true,
+            extension_type: "test_type".to_string(),
+        };
+        let operation_status = crate::telemetry::OperationStatus {
+            operation_success: true,
+            operation: "test_operation".to_string(),
+            task_name: "test_task".to_string(),
+            message: "test_message".to_string(),
+            duration: 100,
+        };
+        let event = crate::telemetry::ExtensionStatusEvent::new(
+            extension.clone(),
+            operation_status.clone(),
+        );
+
+        // Write extension event files with proper naming pattern
+        let mut file_path = events_dir.to_path_buf();
+        file_path.push(crate::telemetry::new_extension_event_file_name());
+        misc_helpers::json_write_to_file(&event, &file_path).unwrap();
+
+        tokio::time::sleep(Duration::from_millis(1)).await;
+
+        let mut file_path2 = events_dir.to_path_buf();
+        file_path2.push(crate::telemetry::new_extension_event_file_name());
+        misc_helpers::json_write_to_file(&event, &file_path2).unwrap();
+
+        // Verify files were created
+        let files = misc_helpers::search_files(
+            &events_dir,
+            crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_PATTERN,
+        )
+        .unwrap();
+        assert_eq!(2, files.len(), "Should have 2 extension event files");
+
+        // Process extension status events directly (without starting the loop)
+        let events_processed = event_reader.process_extension_status_events().await;
+        assert_eq!(
+            2, events_processed,
+            "Should have processed 2 extension status events"
+        );
+
+        // Verify files were cleaned up after processing
+        let files = misc_helpers::search_files(
+            &events_dir,
+            crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_PATTERN,
+        )
+        .unwrap();
+        assert!(
+            files.is_empty(),
+            "Extension event files should be cleaned up after processing"
+        );
+
+        // Test with non-matching file names (should not be processed)
+        let mut non_matching_file = events_dir.to_path_buf();
+        non_matching_file.push("not_extension_event.json");
+        misc_helpers::json_write_to_file(&event, &non_matching_file).unwrap();
+
+        let events_processed = event_reader.process_extension_status_events().await;
+        assert_eq!(
+            0, events_processed,
+            "Should not process files with non-matching names"
+        );
+
+        // Non-matching file should still exist
+        assert!(
+            non_matching_file.exists(),
+            "Non-matching file should not be cleaned up"
+        );
+
+        // Test start_extension_status_event_processor with cancellation
+        // Write another event file
+        let mut file_path3 = events_dir.to_path_buf();
+        file_path3.push(crate::telemetry::new_extension_event_file_name());
+        misc_helpers::json_write_to_file(&event, &file_path3).unwrap();
+
+        // Start the processor in a separate task
+        let event_reader_for_task = EventReader::new(
+            events_dir.clone(),
+            common_state.clone(),
+            "Test".to_string(),
+            "test_extension_status_event_processor".to_string(),
+        );
+        let handle = tokio::spawn(async move {
+            event_reader_for_task
+                .start_extension_status_event_processor(false, Some(Duration::from_millis(50)))
+                .await;
+        });
+
+        // Wait for processing
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Cancel the token to stop the processor
+        common_state.cancel_cancellation_token();
+
+        // Wait for the task to complete
+        let result = tokio::time::timeout(Duration::from_secs(2), handle).await;
+        assert!(
+            result.is_ok(),
+            "Extension status event processor should stop when cancelled"
+        );
+
+        // Verify the file was processed
+        let files = misc_helpers::search_files(
+            &events_dir,
+            crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_PATTERN,
+        )
+        .unwrap();
+        assert!(
+            files.is_empty(),
+            "Extension event file should be processed before cancellation"
+        );
+
+        _ = fs::remove_dir_all(&temp_dir);
+    }
+
+    #[tokio::test]
+    async fn test_mixed_event_files() {
+        let mut temp_dir = env::temp_dir();
+        temp_dir.push("test_mixed_event_files");
+
+        _ = fs::remove_dir_all(&temp_dir);
+        let mut events_dir = temp_dir.to_path_buf();
+        events_dir.push("Events");
+        misc_helpers::try_create_folder(&events_dir).unwrap();
+
+        let cancellation_token = CancellationToken::new();
+        let common_state = CommonState::start_new(cancellation_token.clone());
+        let event_reader = EventReader::new(
+            events_dir.clone(),
+            common_state.clone(),
+            "Test".to_string(),
+            "test_mixed_event_files".to_string(),
+        );
+
+        // Create generic event files (numeric names like 1234567890.json)
+        let message = "Test message for mixed events";
+        let mut generic_events: Vec<Event> = Vec::new();
+        for _ in 0..5 {
+            generic_events.push(Event::new(
+                "Informational".to_string(),
+                message.to_string(),
+                "test_mixed_event_files".to_string(),
+                "test_mixed_event_files".to_string(),
+            ));
+        }
+
+        // Write 2 generic event files
+        let mut generic_file1 = events_dir.to_path_buf();
+        generic_file1.push(crate::telemetry::new_generic_event_file_name());
+        misc_helpers::json_write_to_file(&generic_events, &generic_file1).unwrap();
+
+        tokio::time::sleep(Duration::from_millis(1)).await;
+
+        let mut generic_file2 = events_dir.to_path_buf();
+        generic_file2.push(crate::telemetry::new_generic_event_file_name());
+        misc_helpers::json_write_to_file(&generic_events, &generic_file2).unwrap();
+
+        // Create extension status event files
+        let extension = crate::telemetry::Extension {
+            name: "test_extension".to_string(),
+            version: "1.0.0".to_string(),
+            is_internal: true,
+            extension_type: "test_type".to_string(),
+        };
+        let operation_status = crate::telemetry::OperationStatus {
+            operation_success: true,
+            operation: "test_operation".to_string(),
+            task_name: "test_task".to_string(),
+            message: "test_message".to_string(),
+            duration: 100,
+        };
+        let extension_event = crate::telemetry::ExtensionStatusEvent::new(
+            extension.clone(),
+            operation_status.clone(),
+        );
+
+        // Write 3 extension event files
+        for _ in 0..3 {
+            let mut ext_file = events_dir.to_path_buf();
+            ext_file.push(crate::telemetry::new_extension_event_file_name());
+            misc_helpers::json_write_to_file(&extension_event, &ext_file).unwrap();
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+
+        // Verify all files were created
+        let generic_files = misc_helpers::search_files(
+            &events_dir,
+            crate::telemetry::GENERIC_EVENT_FILE_SEARCH_PATTERN,
+        )
+        .unwrap();
+        assert_eq!(2, generic_files.len(), "Should have 2 generic event files");
+
+        let extension_files = misc_helpers::search_files(
+            &events_dir,
+            crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_PATTERN,
+        )
+        .unwrap();
+        assert_eq!(
+            3,
+            extension_files.len(),
+            "Should have 3 extension event files"
+        );
+
+        // Process generic events using process_once
+        let generic_events_processed = event_reader.process_once().await;
+        assert_eq!(
+            10, generic_events_processed,
+            "Should have processed 10 generic events (5 events x 2 files)"
+        );
+
+        // Verify only generic files were cleaned up
+        let generic_files = misc_helpers::search_files(
+            &events_dir,
+            crate::telemetry::GENERIC_EVENT_FILE_SEARCH_PATTERN,
+        )
+        .unwrap();
+        assert!(
+            generic_files.is_empty(),
+            "Generic event files should be cleaned up"
+        );
+
+        let extension_files = misc_helpers::search_files(
+            &events_dir,
+            crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_PATTERN,
+        )
+        .unwrap();
+        assert_eq!(
+            3,
+            extension_files.len(),
+            "Extension event files should still exist"
+        );
+
+        // Process extension events using process_extension_status_events
+        let extension_events_processed = event_reader.process_extension_status_events().await;
+        assert_eq!(
+            3, extension_events_processed,
+            "Should have processed 3 extension status events"
+        );
+
+        // Verify extension files were cleaned up
+        let extension_files = misc_helpers::search_files(
+            &events_dir,
+            crate::telemetry::EXTENSION_EVENT_FILE_SEARCH_PATTERN,
+        )
+        .unwrap();
+        assert!(
+            extension_files.is_empty(),
+            "Extension event files should be cleaned up"
+        );
+
+        // Test that both processors ignore each other's files
+        // Write one of each type again
+        let mut generic_file = events_dir.to_path_buf();
+        generic_file.push(crate::telemetry::new_generic_event_file_name());
+        misc_helpers::json_write_to_file(&generic_events, &generic_file).unwrap();
+
+        let mut ext_file = events_dir.to_path_buf();
+        ext_file.push(crate::telemetry::new_extension_event_file_name());
+        misc_helpers::json_write_to_file(&extension_event, &ext_file).unwrap();
+
+        // Process extension events - should only process extension file
+        let extension_events_processed = event_reader.process_extension_status_events().await;
+        assert_eq!(
+            1, extension_events_processed,
+            "Should only process extension event file"
+        );
+
+        // Generic file should still exist
+        let generic_files = misc_helpers::search_files(
+            &events_dir,
+            crate::telemetry::GENERIC_EVENT_FILE_SEARCH_PATTERN,
+        )
+        .unwrap();
+        assert_eq!(
+            1,
+            generic_files.len(),
+            "Generic event file should still exist after extension processing"
+        );
+
+        // Process generic events - should only process generic file
+        let generic_events_processed = event_reader.process_once().await;
+        assert_eq!(
+            5, generic_events_processed,
+            "Should only process generic event file"
+        );
+
+        // All files should be cleaned up now
+        let all_files = misc_helpers::get_files(&events_dir).unwrap();
+        assert!(all_files.is_empty(), "All event files should be cleaned up");
+
+        common_state.cancel_cancellation_token();
+        _ = fs::remove_dir_all(&temp_dir);
+    }
 }

--- a/proxy_agent_shared/src/telemetry/event_sender.rs
+++ b/proxy_agent_shared/src/telemetry/event_sender.rs
@@ -221,8 +221,10 @@ pub(crate) fn enqueue_event(event: TelemetryEvent) {
 mod tests {
     use super::*;
     use crate::host_clients::wire_server_client::WireServerClient;
-    use crate::telemetry::telemetry_event::{TelemetryGenericLogsEvent, VmMetaData};
-    use crate::telemetry::Event;
+    use crate::telemetry::telemetry_event::{
+        TelemetryExtensionEventsEvent, TelemetryGenericLogsEvent, VmMetaData,
+    };
+    use crate::telemetry::{Event, ExtensionStatusEvent};
     use tokio_util::sync::CancellationToken;
 
     fn create_test_vm_meta_data() -> VmMetaData {
@@ -251,6 +253,39 @@ mod tests {
             "test_event_name".to_string(),
             Some("1.0.0".to_string()),
         ))
+    }
+
+    fn create_test_extension_event() -> TelemetryEvent {
+        let extension = crate::telemetry::Extension {
+            name: "test_extension".to_string(),
+            version: "1.0.0".to_string(),
+            is_internal: true,
+            extension_type: "test_type".to_string(),
+        };
+        let operation_status = crate::telemetry::OperationStatus {
+            operation_success: true,
+            operation: "install".to_string(),
+            task_name: "test_task".to_string(),
+            message: "Installation successful".to_string(),
+            duration: 500,
+        };
+        let extension_status_event = ExtensionStatusEvent::new(extension, operation_status);
+        let telemetry_event = TelemetryExtensionEventsEvent::from_extension_status_event(
+            &extension_status_event,
+            "production".to_string(),
+            "1.0.0".to_string(),
+        );
+        TelemetryEvent::ExtensionEvent(telemetry_event)
+    }
+
+    #[tokio::test]
+    async fn test_event_sender_new() {
+        let cancellation_token = CancellationToken::new();
+        let common_state = CommonState::start_new(cancellation_token);
+        let event_sender = EventSender::new(common_state);
+
+        // Verify EventSender was created (common_state is private, so we just check it doesn't panic)
+        assert!(std::mem::size_of_val(&event_sender) > 0);
     }
 
     #[tokio::test]
@@ -346,6 +381,135 @@ mod tests {
         assert!(xml.contains("</Provider>"));
     }
 
+    #[test]
+    fn test_extension_event_xml_format() {
+        let vm_meta_data = create_test_vm_meta_data();
+        let vm_data = TelemetryEventVMData::new_from_vm_meta_data(&vm_meta_data);
+
+        // Test extension event XML
+        let event = create_test_extension_event();
+        let event_xml = event.to_xml_event(&vm_data);
+        assert!(event_xml.contains("<Event id=\"1\">"));
+        assert!(event_xml.contains("<![CDATA["));
+        assert!(event_xml.contains("]]></Event>"));
+        assert!(event_xml.contains("ExtensionType"));
+        assert!(event_xml.contains("test_type"));
+        assert!(event_xml.contains("Name"));
+        assert!(event_xml.contains("test_extension"));
+
+        // Test provider ID for extension events
+        assert_eq!(
+            event.get_provider_id(),
+            "69B669B9-4AF8-4C50-BDC4-6006FA76E975"
+        );
+
+        // Test TelemetryData with extension event
+        let mut telemetry_data = TelemetryData::new_with_vm_data(vm_data);
+        telemetry_data.add_event(event);
+        let xml = telemetry_data.to_xml();
+        assert!(xml.contains("<Provider id=\"69B669B9-4AF8-4C50-BDC4-6006FA76E975\">"));
+    }
+
+    #[test]
+    fn test_mixed_events_xml_format() {
+        let vm_meta_data = create_test_vm_meta_data();
+        let vm_data = TelemetryEventVMData::new_from_vm_meta_data(&vm_meta_data);
+
+        let mut telemetry_data = TelemetryData::new_with_vm_data(vm_data);
+
+        // Add generic logs event
+        let generic_event = create_test_event("Test generic message");
+        telemetry_data.add_event(generic_event);
+
+        // Add extension event
+        let extension_event = create_test_extension_event();
+        telemetry_data.add_event(extension_event);
+
+        assert_eq!(telemetry_data.event_count(), 2);
+
+        let xml = telemetry_data.to_xml();
+
+        // Verify both providers are present
+        assert!(xml.contains("<Provider id=\"FFF0196F-EE4C-4EAF-9AA5-776F622DEB4F\">"));
+        assert!(xml.contains("<Provider id=\"69B669B9-4AF8-4C50-BDC4-6006FA76E975\">"));
+        assert!(xml.contains("<Event id=\"7\">")); // Generic logs event
+        assert!(xml.contains("<Event id=\"1\">")); // Extension event
+    }
+
+    #[test]
+    fn test_queue_with_extension_events() {
+        // Create a local bounded queue for testing
+        let test_queue: ConcurrentQueue<TelemetryEvent> = ConcurrentQueue::bounded(10);
+
+        // Add generic and extension events
+        let generic_event = create_test_event("Generic message");
+        let extension_event = create_test_extension_event();
+
+        assert!(test_queue.push(generic_event.clone()).is_ok());
+        assert!(test_queue.push(extension_event.clone()).is_ok());
+
+        assert_eq!(test_queue.len(), 2);
+
+        // Verify FIFO order and event types
+        let popped1 = test_queue.pop();
+        assert!(popped1.is_ok());
+        assert_eq!(
+            popped1.unwrap().get_provider_id(),
+            "FFF0196F-EE4C-4EAF-9AA5-776F622DEB4F"
+        );
+
+        let popped2 = test_queue.pop();
+        assert!(popped2.is_ok());
+        assert_eq!(
+            popped2.unwrap().get_provider_id(),
+            "69B669B9-4AF8-4C50-BDC4-6006FA76E975"
+        );
+
+        assert!(test_queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_update_vm_meta_data_with_mock_server() {
+        let ip = "127.0.0.1";
+        let port = 7072u16;
+
+        let cancellation_token = CancellationToken::new();
+        let common_state = CommonState::start_new(cancellation_token.clone());
+        let event_sender = EventSender::new(common_state.clone());
+
+        // Start mock server
+        tokio::spawn(crate::server_mock::start(
+            ip.to_string(),
+            port,
+            cancellation_token.clone(),
+        ));
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let wire_server_client = WireServerClient::new(ip, port);
+        let imds_client = ImdsClient::new(ip, port);
+
+        // Initially vm_meta_data should be None
+        let vm_meta_data = common_state.get_vm_meta_data().await.unwrap();
+        assert!(vm_meta_data.is_none());
+
+        // Update vm_meta_data
+        let result = event_sender
+            .update_vm_meta_data(&wire_server_client, &imds_client)
+            .await;
+        assert!(result.is_ok(), "update_vm_meta_data should succeed");
+
+        // Verify vm_meta_data was set
+        let vm_meta_data = common_state.get_vm_meta_data().await.unwrap();
+        assert!(vm_meta_data.is_some(), "vm_meta_data should be set");
+
+        let vm_data = vm_meta_data.unwrap();
+        // Values come from mock server responses
+        assert!(!vm_data.container_id.is_empty());
+        assert!(!vm_data.role_name.is_empty());
+
+        cancellation_token.cancel();
+    }
+
     /// Consolidated test for all TELEMETRY_EVENT_QUEUE and wire server operations.
     /// This test must run in a single test function because the global static queue
     /// cannot be reopened once closed. The test covers:
@@ -394,7 +558,22 @@ mod tests {
         event_sender.process_event_queue(None, None).await;
         assert!(TELEMETRY_EVENT_QUEUE.is_empty());
 
-        // ===== Part 3: Test enqueue and process with mock server =====
+        // ===== Part 3: Test enqueue mixed events (generic and extension) =====
+        let generic_event = create_test_event("Generic event for queue");
+        let extension_event = create_test_extension_event();
+
+        enqueue_event(generic_event);
+        enqueue_event(extension_event);
+        assert_eq!(
+            TELEMETRY_EVENT_QUEUE.len(),
+            2,
+            "Queue should have 2 mixed events"
+        );
+
+        // Clear for next test
+        while TELEMETRY_EVENT_QUEUE.pop().is_ok() {}
+
+        // ===== Part 4: Test enqueue and process with mock server =====
         // Enqueue events
         let event_a = create_test_event("Test event A for processing");
         let event_b = create_test_event("Test event B for processing");
@@ -455,7 +634,7 @@ mod tests {
             "Queue should not be closed after processing"
         );
 
-        // ===== Part 4: Test send_data_to_wire_server =====
+        // ===== Part 5: Test send_data_to_wire_server =====
         let wire_server_client = WireServerClient::new(ip, port);
         let vm_meta_data = create_test_vm_meta_data();
         let vm_data = TelemetryEventVMData::new_from_vm_meta_data(&vm_meta_data);
@@ -466,13 +645,20 @@ mod tests {
         EventSender::send_data_to_wire_server(empty_data, &wire_server_client).await;
 
         // Test sending data with events
-        let mut telemetry_data = TelemetryData::new_with_vm_data(vm_data);
+        let mut telemetry_data = TelemetryData::new_with_vm_data(vm_data.clone());
         telemetry_data.add_event(create_test_event("Test event 1"));
         telemetry_data.add_event(create_test_event("Test event 2"));
         assert_eq!(telemetry_data.event_count(), 2);
         EventSender::send_data_to_wire_server(telemetry_data, &wire_server_client).await;
 
-        // ===== Part 5: Test EventSender lifecycle (cancellation) =====
+        // Test sending data with mixed events
+        let mut mixed_data = TelemetryData::new_with_vm_data(vm_data);
+        mixed_data.add_event(create_test_event("Generic event"));
+        mixed_data.add_event(create_test_extension_event());
+        assert_eq!(mixed_data.event_count(), 2);
+        EventSender::send_data_to_wire_server(mixed_data, &wire_server_client).await;
+
+        // ===== Part 6: Test EventSender lifecycle (cancellation) =====
         // This MUST be last as it closes the queue permanently
 
         // Cancel the token - this will close the queue, stop the event sender task and stop mock server

--- a/proxy_agent_shared/src/telemetry/event_sender.rs
+++ b/proxy_agent_shared/src/telemetry/event_sender.rs
@@ -647,6 +647,7 @@ mod tests {
         telemetry_data.add_event(create_test_event("Test event 1"));
         telemetry_data.add_event(create_test_event("Test event 2"));
         assert_eq!(telemetry_data.event_count(), 2);
+        println!("{}", telemetry_data.to_xml());
         EventSender::send_data_to_wire_server(telemetry_data, &wire_server_client).await;
 
         // Test sending data with mixed events

--- a/proxy_agent_shared/src/telemetry/event_sender.rs
+++ b/proxy_agent_shared/src/telemetry/event_sender.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use crate::common_state::{self, CommonState};
 use crate::host_clients::imds_client::ImdsClient;
 use crate::host_clients::wire_server_client::WireServerClient;
-use crate::logger::logger_manager;
+use crate::logger::{logger_manager, LoggerLevel};
 use crate::result::Result;
 use crate::telemetry::telemetry_event::{
     TelemetryData, TelemetryEvent, TelemetryEventVMData, VmMetaData,
@@ -191,12 +191,17 @@ impl EventSender {
             return;
         }
 
+        let event_count = telemetry_data.event_count();
         for _ in [0; 5] {
             match wire_server_client
                 .send_telemetry_data(telemetry_data.to_xml())
                 .await
             {
                 Ok(()) => {
+                    logger_manager::write_log(
+                        LoggerLevel::Trace,
+                        format!("Successfully sent {event_count} telemetry events to wire server."),
+                    );
                     break;
                 }
                 Err(e) => {

--- a/proxy_agent_shared/src/telemetry/telemetry_event.rs
+++ b/proxy_agent_shared/src/telemetry/telemetry_event.rs
@@ -338,6 +338,32 @@ impl TelemetryGenericLogsEvent {
         xml.push_str(&vm_data.to_xml_params());
 
         xml.push_str(&format!(
+            "<Param Name=\"EventPid\" Value=\"{}\" T=\"mt:uint64\" />",
+            self.event_pid
+        ));
+        xml.push_str(&format!(
+            "<Param Name=\"EventTid\" Value=\"{}\" T=\"mt:uint64\" />",
+            self.event_tid
+        ));
+        xml.push_str(&format!(
+            "<Param Name=\"GaVersion\" Value=\"{}\" T=\"mt:wstr\" />",
+            misc_helpers::xml_escape(self.ga_version.to_string())
+        ));
+        xml.push_str(&format!(
+            "<Param Name=\"ExecutionMode\" Value=\"{}\" T=\"mt:wstr\" />",
+            misc_helpers::xml_escape(self.execution_mode.to_string())
+        ));
+        xml.push_str(&format!(
+            "<Param Name=\"TaskName\" Value=\"{}\" T=\"mt:wstr\" />",
+            misc_helpers::xml_escape(self.task_name.to_string())
+        ));
+        xml.push_str(&format!(
+            "<Param Name=\"OpcodeName\" Value=\"{}\" T=\"mt:wstr\" />",
+            misc_helpers::xml_escape(self.opcode_name.to_string())
+        ));
+        
+
+        xml.push_str(&format!(
             "<Param Name=\"EventName\" Value=\"{}\" T=\"mt:wstr\" />",
             misc_helpers::xml_escape(self.event_name.to_string())
         ));
@@ -417,7 +443,30 @@ impl TelemetryExtensionEventsEvent {
 
         xml.push_str(&vm_data.to_xml_params());
 
-        // ... Additional parameters similar to TelemetryGenericLogsEvent
+        xml.push_str(&format!(
+            "<Param Name=\"EventPid\" Value=\"{}\" T=\"mt:uint64\" />",
+            self.event_pid
+        ));
+        xml.push_str(&format!(
+            "<Param Name=\"EventTid\" Value=\"{}\" T=\"mt:uint64\" />",
+            self.event_tid
+        ));
+        xml.push_str(&format!(
+            "<Param Name=\"GaVersion\" Value=\"{}\" T=\"mt:wstr\" />",
+            misc_helpers::xml_escape(self.ga_version.to_string())
+        ));
+        xml.push_str(&format!(
+            "<Param Name=\"ExecutionMode\" Value=\"{}\" T=\"mt:wstr\" />",
+            misc_helpers::xml_escape(self.execution_mode.to_string())
+        ));
+        xml.push_str(&format!(
+            "<Param Name=\"TaskName\" Value=\"{}\" T=\"mt:wstr\" />",
+            misc_helpers::xml_escape(self.task_name.to_string())
+        ));
+        xml.push_str(&format!(
+            "<Param Name=\"OpcodeName\" Value=\"{}\" T=\"mt:wstr\" />",
+            misc_helpers::xml_escape(self.opcode_name.to_string())
+        ));
         xml.push_str(&format!(
             "<Param Name=\"ExtensionType\" Value=\"{}\" T=\"mt:wstr\" />",
             misc_helpers::xml_escape(self.extension_type.to_string())

--- a/proxy_agent_shared/src/telemetry/telemetry_event.rs
+++ b/proxy_agent_shared/src/telemetry/telemetry_event.rs
@@ -361,7 +361,6 @@ impl TelemetryGenericLogsEvent {
             "<Param Name=\"OpcodeName\" Value=\"{}\" T=\"mt:wstr\" />",
             misc_helpers::xml_escape(self.opcode_name.to_string())
         ));
-        
 
         xml.push_str(&format!(
             "<Param Name=\"EventName\" Value=\"{}\" T=\"mt:wstr\" />",

--- a/proxy_agent_shared/src/telemetry/telemetry_event.rs
+++ b/proxy_agent_shared/src/telemetry/telemetry_event.rs
@@ -346,7 +346,7 @@ impl TelemetryGenericLogsEvent {
             self.event_tid
         ));
         xml.push_str(&format!(
-            "<Param Name=\"GaVersion\" Value=\"{}\" T=\"mt:wstr\" />",
+            "<Param Name=\"GAVersion\" Value=\"{}\" T=\"mt:wstr\" />",
             misc_helpers::xml_escape(self.ga_version.to_string())
         ));
         xml.push_str(&format!(
@@ -451,7 +451,7 @@ impl TelemetryExtensionEventsEvent {
             self.event_tid
         ));
         xml.push_str(&format!(
-            "<Param Name=\"GaVersion\" Value=\"{}\" T=\"mt:wstr\" />",
+            "<Param Name=\"GAVersion\" Value=\"{}\" T=\"mt:wstr\" />",
             misc_helpers::xml_escape(self.ga_version.to_string())
         ));
         xml.push_str(&format!(
@@ -923,6 +923,7 @@ mod tests {
         assert!(xml.contains(&format!("<Provider id=\"{}\">", STATUS_PROVIDER_ID)));
         assert!(xml.contains("<Event id=\"7\">")); // Generic logs event
         assert!(xml.contains("<Event id=\"1\">")); // Extension event
+        println!("{xml}");
 
         // Remove extension event
         let removed = telemetry_data.remove_last_event(extension_event);


### PR DESCRIPTION
- Regex::New is performance-sensitive - use LazyLock to compile it only once as a static regex and reuse it for subsequent calls
- Config setting value `get_xxx` in Config invoked `resolve_env_variables` at each call - resolve all the config values at new when first read & parse our config file.
- regex.replace_all's time-complexity is O(m * n^2) in redact_secrets - first check for indicators, just simple substrings to check for before running the more expensive regexes.
- Parse Host & Port from UrI multiple times per each proxied requests - Removed `host_port_from_uri(full_url: &Uri)` abd added struct `HostEndpoint` with `host`, `port` and `path_and_query`
- Update `json_write_to_file` to use BufWriter to reduce system calls and improve performance
- Introduced new `json_write_to_file_async` using `tokio::fs`, provides better throughput in async contexts
- At get date_time string functions, started to use static LazyLock format descriptors. The format strings are now parsed once on first use and reused for all subsequent calls
- misc: avoid format! when only simple concatenation of 2 or less strings, use string.push_str to have direct `memcpy`
- misc: use `string.clone()` over `string.to_string()` to avoid extra trait dispatch + formatting overhead
- misc: `set_stream_read_time_out` to use `socket2::SockRef.set_read_timeout`, it avoids 2 moderate system calls (from tokio TcpStream.into_std and TcpStream.from _std)


